### PR TITLE
Add optional Twitter handle resolver

### DIFF
--- a/cmd/dump/main_test.go
+++ b/cmd/dump/main_test.go
@@ -1,0 +1,135 @@
+package main_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	dumpcmd "github.com/f-sync/fsync/cmd/dump"
+	"github.com/f-sync/fsync/internal/handles"
+)
+
+type stubResolver struct {
+	callCount atomic.Int32
+}
+
+func (resolver *stubResolver) ResolveMany(_ context.Context, _ []string) map[string]handles.Result {
+	resolver.callCount.Add(1)
+	return nil
+}
+
+func TestMaybeResolveHandlesDisabled(t *testing.T) {
+	followerSet := dumpcmd.AccountSets{Followers: map[string]dumpcmd.AccountRecord{"1": {AccountID: "1"}}, Following: map[string]dumpcmd.AccountRecord{"1": {AccountID: "1"}}}
+	resolver := &stubResolver{}
+
+	result := dumpcmd.MaybeResolveHandles(context.Background(), resolver, false, &followerSet)
+	if result != nil {
+		t.Fatalf("expected nil result, got %v", result)
+	}
+	if resolver.callCount.Load() != 0 {
+		t.Fatalf("expected resolver to remain unused")
+	}
+	if followerSet.Followers["1"].UserName != "" {
+		t.Fatalf("expected follower username to remain empty")
+	}
+}
+
+func TestMaybeResolveHandlesEnabled(t *testing.T) {
+	testCases := []struct {
+		name             string
+		configureServer  func(headCount *atomic.Int32, profileCount *atomic.Int32) *httptest.Server
+		expectError      bool
+		expectedUserName string
+		expectedName     string
+	}{
+		{
+			name: "successful resolution",
+			configureServer: func(headCount *atomic.Int32, profileCount *atomic.Int32) *httptest.Server {
+				var server *httptest.Server
+				profilePath := "/resolved"
+				server = httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+					switch {
+					case request.URL.Path == profilePath:
+						profileCount.Add(1)
+						writer.WriteHeader(http.StatusOK)
+						_, _ = writer.Write([]byte("<title>Resolved Name (@resolved) / X</title>"))
+						return
+					case request.URL.Path == "/i/user/1":
+						headCount.Add(1)
+						writer.Header().Set("Location", server.URL+profilePath)
+						writer.WriteHeader(http.StatusFound)
+						return
+					default:
+						writer.WriteHeader(http.StatusNotFound)
+					}
+				}))
+				return server
+			},
+			expectedUserName: "resolved",
+			expectedName:     "Resolved Name",
+		},
+		{
+			name: "resolution failure",
+			configureServer: func(headCount *atomic.Int32, profileCount *atomic.Int32) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+					if request.URL.Path == "/i/user/1" {
+						headCount.Add(1)
+						writer.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					writer.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			var headCount atomic.Int32
+			var profileCount atomic.Int32
+			server := testCase.configureServer(&headCount, &profileCount)
+			t.Cleanup(server.Close)
+
+			resolver, err := handles.NewResolver(handles.Config{BaseURL: server.URL, Client: server.Client(), MaxConcurrent: 2})
+			if err != nil {
+				t.Fatalf("create resolver: %v", err)
+			}
+
+			followerSet := dumpcmd.AccountSets{Followers: map[string]dumpcmd.AccountRecord{"1": {AccountID: "1"}}, Following: map[string]dumpcmd.AccountRecord{"1": {AccountID: "1"}}}
+			result := dumpcmd.MaybeResolveHandles(context.Background(), resolver, true, &followerSet)
+
+			if testCase.expectError {
+				if len(result) == 0 {
+					t.Fatalf("expected errors from resolution")
+				}
+				if followerSet.Followers["1"].UserName != "" {
+					t.Fatalf("expected username to remain empty after failure")
+				}
+				return
+			}
+
+			if len(result) != 0 {
+				t.Fatalf("expected no errors, received %v", result)
+			}
+			if followerSet.Followers["1"].UserName != testCase.expectedUserName {
+				t.Fatalf("unexpected username: %s", followerSet.Followers["1"].UserName)
+			}
+			if followerSet.Followers["1"].DisplayName != testCase.expectedName {
+				t.Fatalf("unexpected display name: %s", followerSet.Followers["1"].DisplayName)
+			}
+			if followerSet.Following["1"].UserName != testCase.expectedUserName {
+				t.Fatalf("expected following record to be enriched")
+			}
+			if headCount.Load() != 1 {
+				t.Fatalf("expected a single redirect lookup, got %d", headCount.Load())
+			}
+			if profileCount.Load() != 1 {
+				t.Fatalf("expected a single profile fetch, got %d", profileCount.Load())
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/f-sync/fsync
+
+go 1.21
+
+require golang.org/x/sync v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=

--- a/internal/handles/doc.go
+++ b/internal/handles/doc.go
@@ -1,0 +1,2 @@
+// Package handles resolves Twitter account handles and display names for numeric IDs.
+package handles

--- a/internal/handles/resolver.go
+++ b/internal/handles/resolver.go
@@ -1,0 +1,371 @@
+package handles
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	defaultBaseURLString            = "https://twitter.com"
+	userPathFormat                  = "/i/user/%s"
+	locationHeaderName              = "Location"
+	titleStartTag                   = "<title>"
+	titleEndTag                     = "</title>"
+	titleHandleDelimiter            = "(@"
+	titleSuffixDelimiter            = " / "
+	whitespaceCharacters            = " \t\r\n"
+	errMessageEmptyAccountID        = "account id cannot be empty"
+	errMessageMissingLocationHeader = "twitter profile redirect did not include a location header"
+	errMessageNoRedirect            = "twitter profile request did not return a redirect"
+	errMessageUnexpectedStatus      = "twitter profile request returned unexpected status code"
+	errMessageMissingHandle         = "twitter profile redirect did not contain a handle"
+	defaultUserAgentHeader          = "User-Agent"
+	defaultUserAgentValue           = "F-Sync-HandleResolver/1.0"
+	maxProfileHTMLBytes             = 128 * 1024
+	defaultDialTimeout              = 5 * time.Second
+	defaultTLSHandshakeTimeout      = 5 * time.Second
+	defaultResponseHeaderTimeout    = 10 * time.Second
+	defaultHTTPTimeout              = 15 * time.Second
+	defaultWorkerConcurrency        = 8
+)
+
+var (
+	errEmptyAccountID        = errors.New(errMessageEmptyAccountID)
+	errMissingLocationHeader = errors.New(errMessageMissingLocationHeader)
+	errNoRedirect            = errors.New(errMessageNoRedirect)
+	errMissingHandle         = errors.New(errMessageMissingHandle)
+)
+
+// AccountRecord captures the resolved handle information for a Twitter account.
+type AccountRecord struct {
+	AccountID   string
+	UserName    string
+	DisplayName string
+}
+
+// Result represents the outcome of a resolve attempt.
+type Result struct {
+	Record AccountRecord
+	Err    error
+}
+
+// Config customizes a Resolver instance.
+type Config struct {
+	BaseURL       string
+	Client        *http.Client
+	MaxConcurrent int
+}
+
+// Resolver resolves Twitter handles for numeric account identifiers.
+type Resolver struct {
+	client      *http.Client
+	baseURL     *url.URL
+	workerCount int
+	cache       map[string]cacheEntry
+	cacheMutex  sync.RWMutex
+	flightGroup singleflight.Group
+}
+
+type cacheEntry struct {
+	record AccountRecord
+	err    error
+}
+
+// NewResolver constructs a Resolver with sensible defaults for HTTP timeouts and redirect handling.
+func NewResolver(configuration Config) (*Resolver, error) {
+	baseURLString := configuration.BaseURL
+	if strings.TrimSpace(baseURLString) == "" {
+		baseURLString = defaultBaseURLString
+	}
+	parsedBaseURL, err := url.Parse(baseURLString)
+	if err != nil {
+		return nil, fmt.Errorf("parse base url: %w", err)
+	}
+
+	httpClient := configuration.Client
+	if httpClient == nil {
+		httpClient = newHTTPClient()
+	} else {
+		clonedClient := *httpClient
+		if clonedClient.Transport == nil {
+			clonedClient.Transport = defaultTransport()
+		}
+		clonedClient.CheckRedirect = preventRedirectFollowing
+		httpClient = &clonedClient
+	}
+	if httpClient.Timeout == 0 {
+		httpClient.Timeout = defaultHTTPTimeout
+	}
+
+	workerCount := configuration.MaxConcurrent
+	if workerCount <= 0 {
+		workerCount = defaultWorkerConcurrency
+	}
+
+	resolver := &Resolver{
+		client:      httpClient,
+		baseURL:     parsedBaseURL,
+		workerCount: workerCount,
+		cache:       make(map[string]cacheEntry),
+	}
+	return resolver, nil
+}
+
+// ResolveMany resolves a batch of account identifiers using a bounded worker pool.
+func (resolver *Resolver) ResolveMany(ctx context.Context, accountIDs []string) map[string]Result {
+	uniqueAccountIDs := resolver.uniqueIDs(accountIDs)
+	results := make(map[string]Result, len(uniqueAccountIDs))
+	if len(uniqueAccountIDs) == 0 {
+		return results
+	}
+
+	var (
+		resultsMutex sync.Mutex
+		group        errgroup.Group
+	)
+	group.SetLimit(resolver.workerCount)
+	for _, accountID := range uniqueAccountIDs {
+		accountID := accountID
+		group.Go(func() error {
+			record, err := resolver.ResolveAccount(ctx, accountID)
+			resultsMutex.Lock()
+			results[accountID] = Result{Record: record, Err: err}
+			resultsMutex.Unlock()
+			return nil
+		})
+	}
+	_ = group.Wait()
+	return results
+}
+
+// ResolveAccount resolves a single numeric account identifier into handle metadata.
+func (resolver *Resolver) ResolveAccount(ctx context.Context, accountID string) (AccountRecord, error) {
+	if strings.TrimSpace(accountID) == "" {
+		return AccountRecord{}, errEmptyAccountID
+	}
+
+	resolver.cacheMutex.RLock()
+	if entry, ok := resolver.cache[accountID]; ok {
+		resolver.cacheMutex.RUnlock()
+		return entry.record, entry.err
+	}
+	resolver.cacheMutex.RUnlock()
+
+	resultChannel := resolver.flightGroup.DoChan(accountID, func() (interface{}, error) {
+		record, fetchErr := resolver.fetchAccount(ctx, accountID)
+		resolver.cacheMutex.Lock()
+		resolver.cache[accountID] = cacheEntry{record: record, err: fetchErr}
+		resolver.cacheMutex.Unlock()
+		if fetchErr != nil {
+			return record, fetchErr
+		}
+		return record, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		return AccountRecord{}, ctx.Err()
+	case result := <-resultChannel:
+		if result.Err != nil {
+			return AccountRecord{}, result.Err
+		}
+		record, _ := result.Val.(AccountRecord)
+		return record, nil
+	}
+}
+
+func (resolver *Resolver) fetchAccount(ctx context.Context, accountID string) (AccountRecord, error) {
+	profile := AccountRecord{AccountID: accountID}
+	redirectURL, err := resolver.resolveRedirect(ctx, accountID)
+	if err != nil {
+		return profile, err
+	}
+
+	handle, err := resolver.extractHandle(redirectURL)
+	if err != nil {
+		return profile, err
+	}
+	profile.UserName = handle
+
+	displayName, displayErr := resolver.fetchDisplayName(ctx, redirectURL)
+	if displayErr == nil && strings.TrimSpace(displayName) != "" {
+		profile.DisplayName = displayName
+	}
+	return profile, nil
+}
+
+func (resolver *Resolver) resolveRedirect(ctx context.Context, accountID string) (string, error) {
+	profileURL := resolver.baseURL.ResolveReference(&url.URL{Path: fmt.Sprintf(userPathFormat, accountID)}).String()
+	redirectURL, err := resolver.requestRedirect(ctx, http.MethodHead, profileURL)
+	if err != nil {
+		if !errors.Is(err, errNoRedirect) && !errors.Is(err, errMissingLocationHeader) {
+			return "", err
+		}
+	}
+	if redirectURL != "" {
+		return redirectURL, nil
+	}
+	return resolver.requestRedirect(ctx, http.MethodGet, profileURL)
+}
+
+func (resolver *Resolver) requestRedirect(ctx context.Context, method string, requestURL string) (string, error) {
+	httpRequest, err := http.NewRequestWithContext(ctx, method, requestURL, nil)
+	if err != nil {
+		return "", err
+	}
+	httpRequest.Header.Set(defaultUserAgentHeader, defaultUserAgentValue)
+
+	httpResponse, err := resolver.client.Do(httpRequest)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		io.Copy(io.Discard, io.LimitReader(httpResponse.Body, 1024))
+		httpResponse.Body.Close()
+	}()
+
+	if isRedirectStatus(httpResponse.StatusCode) {
+		location := httpResponse.Header.Get(locationHeaderName)
+		if strings.TrimSpace(location) == "" {
+			return "", errMissingLocationHeader
+		}
+		return location, nil
+	}
+	if httpResponse.StatusCode == http.StatusMethodNotAllowed {
+		return "", errNoRedirect
+	}
+	if httpResponse.StatusCode >= 200 && httpResponse.StatusCode < 300 {
+		return "", errNoRedirect
+	}
+	return "", fmt.Errorf("%s: %d", errMessageUnexpectedStatus, httpResponse.StatusCode)
+}
+
+func (resolver *Resolver) extractHandle(locationValue string) (string, error) {
+	parsedLocation, err := url.Parse(locationValue)
+	if err != nil {
+		return "", err
+	}
+	path := strings.Trim(parsedLocation.Path, "/")
+	if path == "" {
+		return "", errMissingHandle
+	}
+	segments := strings.Split(path, "/")
+	handle := segments[len(segments)-1]
+	if strings.TrimSpace(handle) == "" {
+		return "", errMissingHandle
+	}
+	return handle, nil
+}
+
+func (resolver *Resolver) fetchDisplayName(ctx context.Context, locationValue string) (string, error) {
+	profileURL, err := resolver.combineURL(locationValue)
+	if err != nil {
+		return "", err
+	}
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, profileURL, nil)
+	if err != nil {
+		return "", err
+	}
+	httpRequest.Header.Set(defaultUserAgentHeader, defaultUserAgentValue)
+
+	httpResponse, err := resolver.client.Do(httpRequest)
+	if err != nil {
+		return "", err
+	}
+	defer httpResponse.Body.Close()
+
+	if httpResponse.StatusCode < 200 || httpResponse.StatusCode >= 300 {
+		return "", fmt.Errorf("%s: %d", errMessageUnexpectedStatus, httpResponse.StatusCode)
+	}
+	limitedReader := io.LimitReader(httpResponse.Body, maxProfileHTMLBytes)
+	htmlBytes, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return "", err
+	}
+	return parseDisplayName(string(htmlBytes)), nil
+}
+
+func (resolver *Resolver) combineURL(locationValue string) (string, error) {
+	parsedLocation, err := url.Parse(locationValue)
+	if err != nil {
+		return "", err
+	}
+	resolved := resolver.baseURL.ResolveReference(parsedLocation)
+	return resolved.String(), nil
+}
+
+func parseDisplayName(htmlContent string) string {
+	startIndex := strings.Index(htmlContent, titleStartTag)
+	if startIndex == -1 {
+		return ""
+	}
+	startIndex += len(titleStartTag)
+	endIndex := strings.Index(htmlContent[startIndex:], titleEndTag)
+	if endIndex == -1 {
+		return ""
+	}
+	endIndex += startIndex
+	titleContent := strings.Trim(htmlContent[startIndex:endIndex], whitespaceCharacters)
+	if cutIndex := strings.Index(titleContent, titleSuffixDelimiter); cutIndex >= 0 {
+		titleContent = strings.Trim(titleContent[:cutIndex], whitespaceCharacters)
+	}
+	if cutIndex := strings.Index(titleContent, titleHandleDelimiter); cutIndex >= 0 {
+		titleContent = strings.Trim(titleContent[:cutIndex], whitespaceCharacters)
+	}
+	return titleContent
+}
+
+func (resolver *Resolver) uniqueIDs(accountIDs []string) []string {
+	unique := make([]string, 0, len(accountIDs))
+	seen := make(map[string]struct{}, len(accountIDs))
+	for _, accountID := range accountIDs {
+		if strings.TrimSpace(accountID) == "" {
+			continue
+		}
+		if _, exists := seen[accountID]; exists {
+			continue
+		}
+		seen[accountID] = struct{}{}
+		unique = append(unique, accountID)
+	}
+	return unique
+}
+
+func isRedirectStatus(statusCode int) bool {
+	return statusCode >= 300 && statusCode < 400
+}
+
+func newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:       defaultHTTPTimeout,
+		Transport:     defaultTransport(),
+		CheckRedirect: preventRedirectFollowing,
+	}
+}
+
+func defaultTransport() http.RoundTripper {
+	return &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: defaultDialTimeout, KeepAlive: 30 * time.Second}).DialContext,
+		TLSHandshakeTimeout:   defaultTLSHandshakeTimeout,
+		IdleConnTimeout:       90 * time.Second,
+		MaxIdleConns:          100,
+		MaxConnsPerHost:       100,
+		ResponseHeaderTimeout: defaultResponseHeaderTimeout,
+	}
+}
+
+func preventRedirectFollowing(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
+}


### PR DESCRIPTION
## Summary
- add an internal handle resolver that performs cached, timeout-bound lookups for numeric account IDs
- add the --resolve-handles flag to optionally enrich parsed exports before rendering and surface lookup warnings
- cover the enrichment flow with table-driven tests and document the new flag and its network impact

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c9eb91176883278cbbfe573f471046