### PR TITLE
Revamp account card presentation in dump output

### DIFF
--- a/cmd/dump/base.css
+++ b/cmd/dump/base.css
@@ -41,18 +41,57 @@ ul {
     list-style: none
 }
 
-li {
-    padding: 6px 0;
-    border-bottom: 1px solid #f0f0f0
+.account-list {
+    margin-top: 12px
 }
 
-li:last-child {
+.account-card {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    padding: 10px 0;
+    border-bottom: 1px solid #e6e6e6
+}
+
+.account-card:last-child {
     border-bottom: none
 }
 
-.matrix li {
-    font-size: 10px;
-    line-height: 1.2
+.account-card-main {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    width: 100%
+}
+
+.account-card-link {
+    color: inherit;
+    text-decoration: none
+}
+
+.account-card-link:hover .account-display {
+    text-decoration: underline
+}
+
+.account-display {
+    font-weight: 600;
+    font-size: 14px;
+    color: #1c1c1c
+}
+
+.account-handle {
+    font-size: 12px;
+    color: #5f6368
+}
+
+.account-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    font-size: 11px;
+    color: #333
 }
 
 a {
@@ -68,13 +107,16 @@ a:hover {
     padding: 2px 8px;
     border: 1px solid #ccc;
     border-radius: 12px;
-    margin-left: 8px;
     font-size: 12px;
     text-decoration: none
 }
 
 .btn:hover {
     background: #f5f5f5
+}
+
+.account-meta .btn {
+    margin-left: 0
 }
 
 .muted {
@@ -84,19 +126,22 @@ a:hover {
 
 .badge {
     display: inline-block;
-    padding: 1px 6px;
-    border: 1px solid #bbb;
+    padding: 2px 8px;
     border-radius: 999px;
-    font-size: 10px;
-    margin-left: 6px
+    font-size: 11px;
+    font-weight: 600;
+    background: #f2f3f5;
+    color: #333
 }
 
 .badge-muted {
-    border-color: #888
+    background: #e8edff;
+    color: #4257b2
 }
 
 .badge-block {
-    border-color: #c00
+    background: #fde8e7;
+    color: #b42318
 }
 
 @media (max-width: 900px) {

--- a/cmd/dump/main_test.go
+++ b/cmd/dump/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -129,6 +130,88 @@ func TestMaybeResolveHandlesEnabled(t *testing.T) {
 			}
 			if profileCount.Load() != 1 {
 				t.Fatalf("expected a single profile fetch, got %d", profileCount.Load())
+			}
+		})
+	}
+}
+
+func TestRenderComparisonPageStructure(t *testing.T) {
+	const (
+		snippetAccountCard      = "class=\"account-card\""
+		snippetAccountDisplay   = "<strong class=\"account-display\">Muted Blocked</strong>"
+		snippetAccountHandle    = "<span class=\"account-handle\">@presented</span>"
+		snippetMutedBadge       = "<span class=\"badge badge-muted\">Muted</span>"
+		snippetBlockedBadge     = "<span class=\"badge badge-block\">Blocked</span>"
+		snippetEmbeddedCSSClass = ".account-card-link:hover .account-display {"
+		snippetEmptyPlaceholder = "<p class=\"muted\">None</p>"
+	)
+
+	decoratedRecord := dumpcmd.AccountRecord{AccountID: "42", UserName: "presented", DisplayName: "Muted Blocked"}
+
+	testCases := []struct {
+		name             string
+		comparison       dumpcmd.ComparisonResult
+		expectedSnippets []string
+	}{
+		{
+			name: "renders account cards with badges",
+			comparison: dumpcmd.ComparisonResult{
+				AccountSetsA: dumpcmd.AccountSets{
+					Followers: map[string]dumpcmd.AccountRecord{"42": decoratedRecord},
+					Following: map[string]dumpcmd.AccountRecord{"42": decoratedRecord},
+					Muted:     map[string]bool{"42": true},
+					Blocked:   map[string]bool{"42": true},
+				},
+				AccountSetsB:        dumpcmd.AccountSets{Muted: map[string]bool{}, Blocked: map[string]bool{}},
+				OwnerA:              dumpcmd.OwnerIdentity{AccountID: "1", UserName: "owner_a", DisplayName: "Owner A"},
+				OwnerB:              dumpcmd.OwnerIdentity{AccountID: "2", UserName: "owner_b", DisplayName: "Owner B"},
+				OwnerAFriends:       []dumpcmd.AccountRecord{decoratedRecord},
+				OwnerABlockedAll:    []dumpcmd.AccountRecord{decoratedRecord},
+				OwnerAFollowersAll:  []dumpcmd.AccountRecord{decoratedRecord},
+				OwnerAFollowingsAll: []dumpcmd.AccountRecord{decoratedRecord},
+			},
+			expectedSnippets: []string{
+				snippetAccountCard,
+				snippetAccountDisplay,
+				snippetAccountHandle,
+				snippetMutedBadge,
+				snippetBlockedBadge,
+				snippetEmbeddedCSSClass,
+			},
+		},
+		{
+			name: "renders placeholder for empty lists",
+			comparison: dumpcmd.ComparisonResult{
+				AccountSetsA: dumpcmd.AccountSets{
+					Followers: map[string]dumpcmd.AccountRecord{},
+					Following: map[string]dumpcmd.AccountRecord{},
+					Muted:     map[string]bool{},
+					Blocked:   map[string]bool{},
+				},
+				AccountSetsB: dumpcmd.AccountSets{
+					Followers: map[string]dumpcmd.AccountRecord{},
+					Following: map[string]dumpcmd.AccountRecord{},
+					Muted:     map[string]bool{},
+					Blocked:   map[string]bool{},
+				},
+			},
+			expectedSnippets: []string{
+				snippetEmptyPlaceholder,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			html, err := dumpcmd.RenderComparisonPage(testCase.comparison)
+			if err != nil {
+				t.Fatalf("RenderComparisonPage: %v", err)
+			}
+			for _, snippet := range testCase.expectedSnippets {
+				if !strings.Contains(html, snippet) {
+					t.Fatalf("expected HTML to contain %q", snippet)
+				}
 			}
 		})
 	}

--- a/cmd/dump/web/static/base.css
+++ b/cmd/dump/web/static/base.css
@@ -1,20 +1,151 @@
-body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, sans-serif; margin: 24px; line-height: 1.45 }
-h1, h2, h3 { margin: 0 0 12px }
-header p, footer p { color: #555 }
-.grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px }
-.matrix { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px }
-.cell { border: 1px solid #ddd; border-radius: 8px; padding: 12px; min-height: 80px }
-.sub { margin: 16px 0 8px 0 }
-ul { margin: 8px 0 0; padding: 0; list-style: none }
-li { padding: 6px 0; border-bottom: 1px solid #f0f0f0 }
-li:last-child { border-bottom: none }
-.matrix li { font-size: 10px; line-height: 1.2 }
-a { text-decoration: none }
-a:hover { text-decoration: underline }
-.btn { display: inline-block; padding: 2px 8px; border: 1px solid #ccc; border-radius: 12px; margin-left: 8px; font-size: 12px; text-decoration: none }
-.btn:hover { background: #f5f5f5 }
-.muted { color: #777; font-size: 12px }
-.badge { display: inline-block; padding: 1px 6px; border: 1px solid #bbb; border-radius: 999px; font-size: 10px; margin-left: 6px }
-.badge-muted { border-color: #888 }
-.badge-block { border-color: #c00 }
-@media (max-width: 900px) { .grid, .matrix { grid-template-columns: 1fr } }
+body {
+    font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, sans-serif;
+    margin: 24px;
+    line-height: 1.45
+}
+
+h1, h2, h3 {
+    margin: 0 0 12px
+}
+
+header p, footer p {
+    color: #555
+}
+
+.grid {
+    display: grid;
+    grid-template-columns:1fr 1fr;
+    gap: 16px
+}
+
+.matrix {
+    display: grid;
+    grid-template-columns:1fr 1fr 1fr;
+    gap: 16px
+}
+
+.cell {
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 12px;
+    min-height: 80px
+}
+
+.sub {
+    margin: 16px 0 8px 0
+}
+
+ul {
+    margin: 8px 0 0 0;
+    padding: 0;
+    list-style: none
+}
+
+.account-list {
+    margin-top: 12px
+}
+
+.account-card {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    padding: 10px 0;
+    border-bottom: 1px solid #e6e6e6
+}
+
+.account-card:last-child {
+    border-bottom: none
+}
+
+.account-card-main {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    width: 100%
+}
+
+.account-card-link {
+    color: inherit;
+    text-decoration: none
+}
+
+.account-card-link:hover .account-display {
+    text-decoration: underline
+}
+
+.account-display {
+    font-weight: 600;
+    font-size: 14px;
+    color: #1c1c1c
+}
+
+.account-handle {
+    font-size: 12px;
+    color: #5f6368
+}
+
+.account-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    font-size: 11px;
+    color: #333
+}
+
+a {
+    text-decoration: none
+}
+
+a:hover {
+    text-decoration: underline
+}
+
+.btn {
+    display: inline-block;
+    padding: 2px 8px;
+    border: 1px solid #ccc;
+    border-radius: 12px;
+    font-size: 12px;
+    text-decoration: none
+}
+
+.btn:hover {
+    background: #f5f5f5
+}
+
+.account-meta .btn {
+    margin-left: 0
+}
+
+.muted {
+    color: #777;
+    font-size: 12px
+}
+
+.badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    background: #f2f3f5;
+    color: #333
+}
+
+.badge-muted {
+    background: #e8edff;
+    color: #4257b2
+}
+
+.badge-block {
+    background: #fde8e7;
+    color: #b42318
+}
+
+@media (max-width: 900px) {
+    .grid, .matrix {
+        grid-template-columns:1fr
+    }
+}

--- a/cmd/dump/web/templates/index.tmpl
+++ b/cmd/dump/web/templates/index.tmpl
@@ -45,18 +45,18 @@
 <section>
     <h2>{{ .OwnerA }} — Relationship Matrix</h2>
     <div class="matrix">
-        <div class="cell"><h3>Friends</h3>{{ template "list" .AFriends }}</div>
-        <div class="cell"><h3>Leaders</h3>{{ template "list" .ALeaders }}</div>
-        <div class="cell"><h3>Groupies</h3>{{ template "list" .AGroupies }}</div>
+        <div class="cell"><h3>Friends</h3>{{ template "accountList" .OwnerALists.Friends }}</div>
+        <div class="cell"><h3>Leaders</h3>{{ template "accountList" .OwnerALists.Leaders }}</div>
+        <div class="cell"><h3>Groupies</h3>{{ template "accountList" .OwnerALists.Groupies }}</div>
     </div>
 </section>
 
 <section>
     <h2>{{ .OwnerB }} — Relationship Matrix</h2>
     <div class="matrix">
-        <div class="cell"><h3>Friends</h3>{{ template "list" .BFriends }}</div>
-        <div class="cell"><h3>Leaders</h3>{{ template "list" .BLeaders }}</div>
-        <div class="cell"><h3>Groupies</h3>{{ template "list" .BGroupies }}</div>
+        <div class="cell"><h3>Friends</h3>{{ template "accountList" .OwnerBLists.Friends }}</div>
+        <div class="cell"><h3>Leaders</h3>{{ template "accountList" .OwnerBLists.Leaders }}</div>
+        <div class="cell"><h3>Groupies</h3>{{ template "accountList" .OwnerBLists.Groupies }}</div>
     </div>
 </section>
 
@@ -83,16 +83,16 @@
 
 <section>
     <h2>Blocked accounts — {{ .OwnerA }}</h2>
-    <h3 class="sub">Also in Following</h3>{{ template "list" .ABlockedAndFollowing }}
-    <h3 class="sub">Also in Followers</h3>{{ template "list" .ABlockedAndFollowers }}
-    <h3 class="sub">All Blocked</h3>{{ template "list" .ABlockedAll }}
+    <h3 class="sub">Also in Following</h3>{{ template "accountList" .OwnerALists.BlockedAndFollowing }}
+    <h3 class="sub">Also in Followers</h3>{{ template "accountList" .OwnerALists.BlockedAndFollowers }}
+    <h3 class="sub">All Blocked</h3>{{ template "accountList" .OwnerALists.BlockedAll }}
 </section>
 
 <section>
     <h2>Blocked accounts — {{ .OwnerB }}</h2>
-    <h3 class="sub">Also in Following</h3>{{ template "list" .BBlockedAndFollowing }}
-    <h3 class="sub">Also in Followers</h3>{{ template "list" .BBlockedAndFollowers }}
-    <h3 class="sub">All Blocked</h3>{{ template "list" .BBlockedAll }}
+    <h3 class="sub">Also in Following</h3>{{ template "accountList" .OwnerBLists.BlockedAndFollowing }}
+    <h3 class="sub">Also in Followers</h3>{{ template "accountList" .OwnerBLists.BlockedAndFollowers }}
+    <h3 class="sub">All Blocked</h3>{{ template "accountList" .OwnerBLists.BlockedAll }}
 </section>
 
 <footer><p>Identity & file paths via manifest.js; follow/blocks/mutes via follower.js, following.js, block.js, mute.js.</p></footer>
@@ -101,17 +101,37 @@
 <script id="matrixData" type="application/json">{{ .MatrixJSON }}</script>
 <script>{{ .JS }}</script>
 
-{{ define "list" }}
-    {{ $list := . }}
-    {{ if not $list }}
+{{ define "accountList" }}
+    {{ $entries := . }}
+    {{ if not $entries }}
         <p class="muted">None</p>
     {{ else }}
-        <ul>
-            {{ range $list }}
-                <li><a target="_blank" rel="noopener" href="{{ profileURL . }}">{{ label . }}</a></li>
+        <ul class="account-list">
+            {{ range $entries }}
+                {{ template "accountCard" . }}
             {{ end }}
         </ul>
     {{ end }}
+{{ end }}
+
+{{ define "accountCard" }}
+    {{ $entry := . }}
+    <li class="account-card">
+        <div class="account-card-main">
+            <a class="account-card-link" target="_blank" rel="noopener" href="{{ $entry.Presentation.ProfileURL }}">
+                <strong class="account-display">{{ $entry.Presentation.Display }}</strong>
+            </a>
+            {{ with $handle := $entry.Presentation.Handle }}
+                <span class="account-handle">{{ $handle }}</span>
+            {{ end }}
+        </div>
+        {{ if or $entry.Muted $entry.Blocked }}
+        <div class="account-meta">
+            {{ if $entry.Muted }}<span class="badge badge-muted">Muted</span>{{ end }}
+            {{ if $entry.Blocked }}<span class="badge badge-block">Blocked</span>{{ end }}
+        </div>
+        {{ end }}
+    </li>
 {{ end }}
 
 </body>


### PR DESCRIPTION
## Summary
- enrich the dump view-model with decorated account card data and central rendering helper
- update templates, CSS, and client JS to render rich account cards with badges and follow actions
- add a regression test around RenderComparisonPage to guard the new markup

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c9effbb96c832784831198a69d227e