### PR TITLE
Add table of contents navigation to dump report

### DIFF
--- a/cmd/dump/main_test.go
+++ b/cmd/dump/main_test.go
@@ -137,13 +137,15 @@ func TestMaybeResolveHandlesEnabled(t *testing.T) {
 
 func TestRenderComparisonPageStructure(t *testing.T) {
 	const (
-		snippetAccountCard      = "class=\"account-card\""
-		snippetAccountDisplay   = "<strong class=\"account-display\">Muted Blocked</strong>"
-		snippetAccountHandle    = "<span class=\"account-handle\">@presented</span>"
-		snippetMutedBadge       = "<span class=\"badge badge-muted\">Muted</span>"
-		snippetBlockedBadge     = "<span class=\"badge badge-block\">Blocked</span>"
-		snippetEmbeddedCSSClass = ".account-card-link:hover .account-display {"
-		snippetEmptyPlaceholder = "<p class=\"muted\">None</p>"
+		snippetAccountCard           = "class=\"account-card\""
+		snippetAccountDisplay        = "<strong class=\"account-display\">Muted Blocked</strong>"
+		snippetAccountHandle         = "<span class=\"account-handle\">@presented</span>"
+		snippetMutedBadge            = "<span class=\"badge badge-muted\">Muted</span>"
+		snippetBlockedBadge          = "<span class=\"badge badge-block\">Blocked</span>"
+		snippetEmbeddedCSSClass      = ".account-card-link:hover .account-display {"
+		snippetEmptyPlaceholder      = "<p class=\"muted\">None</p>"
+		snippetTableOfContentsNav    = "<nav class=\"toc\" aria-label=\"Page sections\">"
+		snippetTableOfContentsAnchor = "<a class=\"toc-link\" href=\"#overview\">Overview</a>"
 	)
 
 	decoratedRecord := dumpcmd.AccountRecord{AccountID: "42", UserName: "presented", DisplayName: "Muted Blocked"}
@@ -177,6 +179,8 @@ func TestRenderComparisonPageStructure(t *testing.T) {
 				snippetMutedBadge,
 				snippetBlockedBadge,
 				snippetEmbeddedCSSClass,
+				snippetTableOfContentsNav,
+				snippetTableOfContentsAnchor,
 			},
 		},
 		{
@@ -197,6 +201,8 @@ func TestRenderComparisonPageStructure(t *testing.T) {
 			},
 			expectedSnippets: []string{
 				snippetEmptyPlaceholder,
+				snippetTableOfContentsNav,
+				snippetTableOfContentsAnchor,
 			},
 		},
 	}

--- a/cmd/dump/web/static/base.css
+++ b/cmd/dump/web/static/base.css
@@ -12,6 +12,62 @@ header p, footer p {
     color: #555
 }
 
+.toc {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin: 24px 0;
+    padding: 16px;
+    border: 1px solid #e0e0e0;
+    border-radius: 12px;
+    background: #f9fafb
+}
+
+.toc-title {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    color: #333
+}
+
+.toc-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 0;
+    padding: 0;
+    list-style: none
+}
+
+.toc-item {
+    margin: 0
+}
+
+.toc-link {
+    display: inline-block;
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: 1px solid #d0d7de;
+    background: #fff;
+    color: #1c1c1c;
+    font-size: 14px;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease
+}
+
+.toc-link:hover,
+.toc-link:focus {
+    background: #1c1c1c;
+    color: #fff;
+    border-color: #1c1c1c;
+    text-decoration: none
+}
+
+section {
+    scroll-margin-top: 80px
+}
+
 .grid {
     display: grid;
     grid-template-columns:1fr 1fr;
@@ -142,6 +198,23 @@ a:hover {
 .badge-block {
     background: #fde8e7;
     color: #b42318
+}
+
+@media (max-width: 700px) {
+    .toc {
+        padding: 12px;
+        gap: 10px
+    }
+
+    .toc-list {
+        flex-direction: column;
+        gap: 6px
+    }
+
+    .toc-link {
+        width: 100%;
+        text-align: center
+    }
 }
 
 @media (max-width: 900px) {

--- a/cmd/dump/web/templates/index.tmpl
+++ b/cmd/dump/web/templates/index.tmpl
@@ -12,7 +12,19 @@
     <p>Offline analysis from two archives. No API calls.</p>
 </header>
 
-<section>
+<nav class="toc" aria-label="Page sections">
+    <h2 class="toc-title">Jump to section</h2>
+    <ul class="toc-list">
+        <li class="toc-item"><a class="toc-link" href="#overview">Overview</a></li>
+        <li class="toc-item"><a class="toc-link" href="#owner-a-matrix">{{ .OwnerA }} — Matrix</a></li>
+        <li class="toc-item"><a class="toc-link" href="#owner-b-matrix">{{ .OwnerB }} — Matrix</a></li>
+        <li class="toc-item"><a class="toc-link" href="#comparisons">Comparisons</a></li>
+        <li class="toc-item"><a class="toc-link" href="#owner-a-blocked">{{ .OwnerA }} — Blocked</a></li>
+        <li class="toc-item"><a class="toc-link" href="#owner-b-blocked">{{ .OwnerB }} — Blocked</a></li>
+    </ul>
+</nav>
+
+<section id="overview">
     <h2>Overview</h2>
     <div class="grid">
         <div>
@@ -42,7 +54,7 @@
     </div>
 </section>
 
-<section>
+<section id="owner-a-matrix">
     <h2>{{ .OwnerA }} — Relationship Matrix</h2>
     <div class="matrix">
         <div class="cell"><h3>Friends</h3>{{ template "accountList" .OwnerALists.Friends }}</div>
@@ -51,7 +63,7 @@
     </div>
 </section>
 
-<section>
+<section id="owner-b-matrix">
     <h2>{{ .OwnerB }} — Relationship Matrix</h2>
     <div class="matrix">
         <div class="cell"><h3>Friends</h3>{{ template "accountList" .OwnerBLists.Friends }}</div>
@@ -62,7 +74,7 @@
 
 <!-- Removed the static “B follows that A doesn’t” section -->
 
-<section>
+<section id="comparisons">
     <h2>On-the-fly comparisons</h2>
     <div>
         <label for="cmpOp">Operation:</label>
@@ -81,14 +93,14 @@
     <div id="cmpOut" class="cell" style="margin-top:12px"></div>
 </section>
 
-<section>
+<section id="owner-a-blocked">
     <h2>Blocked accounts — {{ .OwnerA }}</h2>
     <h3 class="sub">Also in Following</h3>{{ template "accountList" .OwnerALists.BlockedAndFollowing }}
     <h3 class="sub">Also in Followers</h3>{{ template "accountList" .OwnerALists.BlockedAndFollowers }}
     <h3 class="sub">All Blocked</h3>{{ template "accountList" .OwnerALists.BlockedAll }}
 </section>
 
-<section>
+<section id="owner-b-blocked">
     <h2>Blocked accounts — {{ .OwnerB }}</h2>
     <h3 class="sub">Also in Following</h3>{{ template "accountList" .OwnerBLists.BlockedAndFollowing }}
     <h3 class="sub">Also in Followers</h3>{{ template "accountList" .OwnerBLists.BlockedAndFollowers }}


### PR DESCRIPTION
## Summary
- add a navigational table of contents to the dump report template with anchors for each section
- style the table of contents for desktop and narrow viewports
- extend tests to ensure the rendered HTML exposes the table of contents markup

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c9fe660aa48327bf7d17d07f092b12