### PR TITLE
Add collapsible sections to dump comparison page

### DIFF
--- a/cmd/dump/main_test.go
+++ b/cmd/dump/main_test.go
@@ -146,6 +146,8 @@ func TestRenderComparisonPageStructure(t *testing.T) {
 		snippetEmptyPlaceholder      = "<p class=\"muted\">None</p>"
 		snippetTableOfContentsNav    = "<nav class=\"toc\" aria-label=\"Page sections\">"
 		snippetTableOfContentsAnchor = "<a class=\"toc-link\" href=\"#overview\">Overview</a>"
+		snippetSectionToggleControl  = "<button type=\"button\" class=\"section-toggle\" data-section-id=\"overview-content\" aria-expanded=\"true\" aria-controls=\"overview-content\">Hide</button>"
+		snippetSectionContent        = "<div class=\"section-content\" id=\"overview-content\">"
 	)
 
 	decoratedRecord := dumpcmd.AccountRecord{AccountID: "42", UserName: "presented", DisplayName: "Muted Blocked"}
@@ -181,6 +183,8 @@ func TestRenderComparisonPageStructure(t *testing.T) {
 				snippetEmbeddedCSSClass,
 				snippetTableOfContentsNav,
 				snippetTableOfContentsAnchor,
+				snippetSectionToggleControl,
+				snippetSectionContent,
 			},
 		},
 		{
@@ -203,6 +207,8 @@ func TestRenderComparisonPageStructure(t *testing.T) {
 				snippetEmptyPlaceholder,
 				snippetTableOfContentsNav,
 				snippetTableOfContentsAnchor,
+				snippetSectionToggleControl,
+				snippetSectionContent,
 			},
 		},
 	}

--- a/cmd/dump/web/static/app.js
+++ b/cmd/dump/web/static/app.js
@@ -21,11 +21,21 @@
     const CLASS_BADGE_BLOCKED = "badge badge-block";
     const CLASS_BUTTON = "btn";
     const CLASS_MUTED_TEXT = "muted";
+    const CLASS_SECTION_TOGGLE = "section-toggle";
+    const CLASS_SECTION_CONTENT = "section-content";
+    const CLASS_HIDDEN = "is-hidden";
     const PROFILE_BASE_URL = "https://twitter.com/";
     const PROFILE_ID_BASE_URL = "https://twitter.com/i/user/";
     const FOLLOW_SCREEN_NAME_URL = "https://twitter.com/intent/follow?screen_name=";
     const FOLLOW_ACCOUNT_ID_URL = "https://twitter.com/intent/user?user_id=";
     const NONE_PLACEHOLDER_HTML = "<p class='" + CLASS_MUTED_TEXT + "'>" + TEXT_NONE + "</p>";
+    const ATTRIBUTE_SECTION_TARGET = "data-section-id";
+    const ATTRIBUTE_ARIA_CONTROLS = "aria-controls";
+    const ATTRIBUTE_ARIA_EXPANDED = "aria-expanded";
+    const VALUE_STATE_TRUE = "true";
+    const VALUE_STATE_FALSE = "false";
+    const TEXT_HIDE = "Hide";
+    const TEXT_SHOW = "Show";
 
     function indexById(arr) {
         const map = new Map();
@@ -226,6 +236,45 @@
     }
 
     document.getElementById("runCmp")?.addEventListener("click", runSelected);
+    attachSectionToggleBehavior();
     // Optionally auto-run the selected option on load:
     // runSelected();
+
+    function attachSectionToggleBehavior() {
+        const toggleButtons = document.querySelectorAll("." + CLASS_SECTION_TOGGLE);
+        toggleButtons.forEach(toggleButton => {
+            if (!(toggleButton instanceof HTMLElement)) return;
+            const sectionIdentifier = toggleButton.getAttribute(ATTRIBUTE_SECTION_TARGET) || "";
+            if (!sectionIdentifier) return;
+            const targetElement = document.getElementById(sectionIdentifier);
+            if (!(targetElement instanceof HTMLElement)) return;
+            if (!targetElement.classList.contains(CLASS_SECTION_CONTENT)) return;
+            toggleButton.addEventListener("click", event => {
+                event.preventDefault();
+                toggleSectionVisibility(toggleButton, targetElement);
+            });
+            const shouldStartHidden = targetElement.classList.contains(CLASS_HIDDEN);
+            updateSectionVisibility(toggleButton, targetElement, shouldStartHidden);
+            if (!toggleButton.getAttribute(ATTRIBUTE_ARIA_CONTROLS)) {
+                toggleButton.setAttribute(ATTRIBUTE_ARIA_CONTROLS, sectionIdentifier);
+            }
+        });
+    }
+
+    function toggleSectionVisibility(toggleButton, targetElement) {
+        const isCurrentlyHidden = targetElement.classList.contains(CLASS_HIDDEN);
+        updateSectionVisibility(toggleButton, targetElement, !isCurrentlyHidden);
+    }
+
+    function updateSectionVisibility(toggleButton, targetElement, shouldHide) {
+        if (shouldHide) {
+            targetElement.classList.add(CLASS_HIDDEN);
+            toggleButton.setAttribute(ATTRIBUTE_ARIA_EXPANDED, VALUE_STATE_FALSE);
+            toggleButton.textContent = TEXT_SHOW;
+        } else {
+            targetElement.classList.remove(CLASS_HIDDEN);
+            toggleButton.setAttribute(ATTRIBUTE_ARIA_EXPANDED, VALUE_STATE_TRUE);
+            toggleButton.textContent = TEXT_HIDE;
+        }
+    }
 })();

--- a/cmd/dump/web/static/base.css
+++ b/cmd/dump/web/static/base.css
@@ -68,6 +68,42 @@ section {
     scroll-margin-top: 80px
 }
 
+.section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px
+}
+
+.section-toggle {
+    padding: 6px 12px;
+    border: 1px solid #d0d7de;
+    border-radius: 999px;
+    background: #fff;
+    color: #1c1c1c;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease
+}
+
+.section-toggle:hover,
+.section-toggle:focus {
+    background: #1c1c1c;
+    color: #fff;
+    border-color: #1c1c1c;
+    outline: none
+}
+
+.section-content.is-hidden {
+    display: none
+}
+
+.is-hidden {
+    display: none !important
+}
+
 .grid {
     display: grid;
     grid-template-columns:1fr 1fr;

--- a/cmd/dump/web/templates/index.tmpl
+++ b/cmd/dump/web/templates/index.tmpl
@@ -25,86 +25,116 @@
 </nav>
 
 <section id="overview">
-    <h2>Overview</h2>
-    <div class="grid">
-        <div>
-            <h3>{{ .OwnerA }}</h3>
-            <ul>
-                <li>Followers: {{ .Counts.A.Followers }}</li>
-                <li>Followings: {{ .Counts.A.Following }}</li>
-                <li>Friends: {{ .Counts.A.Friends }}</li>
-                <li>Leaders: {{ .Counts.A.Leaders }}</li>
-                <li>Groupies: {{ .Counts.A.Groupies }}</li>
-                <li>Muted: {{ .Counts.A.Muted }}</li>
-                <li>Blocked: {{ .Counts.A.Blocked }}</li>
-            </ul>
-        </div>
-        <div>
-            <h3>{{ .OwnerB }}</h3>
-            <ul>
-                <li>Followers: {{ .Counts.B.Followers }}</li>
-                <li>Followings: {{ .Counts.B.Following }}</li>
-                <li>Friends: {{ .Counts.B.Friends }}</li>
-                <li>Leaders: {{ .Counts.B.Leaders }}</li>
-                <li>Groupies: {{ .Counts.B.Groupies }}</li>
-                <li>Muted: {{ .Counts.B.Muted }}</li>
-                <li>Blocked: {{ .Counts.B.Blocked }}</li>
-            </ul>
+    <div class="section-header">
+        <h2>Overview</h2>
+        <button type="button" class="section-toggle" data-section-id="overview-content" aria-expanded="true" aria-controls="overview-content">Hide</button>
+    </div>
+    <div class="section-content" id="overview-content">
+        <div class="grid">
+            <div>
+                <h3>{{ .OwnerA }}</h3>
+                <ul>
+                    <li>Followers: {{ .Counts.A.Followers }}</li>
+                    <li>Followings: {{ .Counts.A.Following }}</li>
+                    <li>Friends: {{ .Counts.A.Friends }}</li>
+                    <li>Leaders: {{ .Counts.A.Leaders }}</li>
+                    <li>Groupies: {{ .Counts.A.Groupies }}</li>
+                    <li>Muted: {{ .Counts.A.Muted }}</li>
+                    <li>Blocked: {{ .Counts.A.Blocked }}</li>
+                </ul>
+            </div>
+            <div>
+                <h3>{{ .OwnerB }}</h3>
+                <ul>
+                    <li>Followers: {{ .Counts.B.Followers }}</li>
+                    <li>Followings: {{ .Counts.B.Following }}</li>
+                    <li>Friends: {{ .Counts.B.Friends }}</li>
+                    <li>Leaders: {{ .Counts.B.Leaders }}</li>
+                    <li>Groupies: {{ .Counts.B.Groupies }}</li>
+                    <li>Muted: {{ .Counts.B.Muted }}</li>
+                    <li>Blocked: {{ .Counts.B.Blocked }}</li>
+                </ul>
+            </div>
         </div>
     </div>
 </section>
 
 <section id="owner-a-matrix">
-    <h2>{{ .OwnerA }} — Relationship Matrix</h2>
-    <div class="matrix">
-        <div class="cell"><h3>Friends</h3>{{ template "accountList" .OwnerALists.Friends }}</div>
-        <div class="cell"><h3>Leaders</h3>{{ template "accountList" .OwnerALists.Leaders }}</div>
-        <div class="cell"><h3>Groupies</h3>{{ template "accountList" .OwnerALists.Groupies }}</div>
+    <div class="section-header">
+        <h2>{{ .OwnerA }} — Relationship Matrix</h2>
+        <button type="button" class="section-toggle" data-section-id="owner-a-matrix-content" aria-expanded="true" aria-controls="owner-a-matrix-content">Hide</button>
+    </div>
+    <div class="section-content" id="owner-a-matrix-content">
+        <div class="matrix">
+            <div class="cell"><h3>Friends</h3>{{ template "accountList" .OwnerALists.Friends }}</div>
+            <div class="cell"><h3>Leaders</h3>{{ template "accountList" .OwnerALists.Leaders }}</div>
+            <div class="cell"><h3>Groupies</h3>{{ template "accountList" .OwnerALists.Groupies }}</div>
+        </div>
     </div>
 </section>
 
 <section id="owner-b-matrix">
-    <h2>{{ .OwnerB }} — Relationship Matrix</h2>
-    <div class="matrix">
-        <div class="cell"><h3>Friends</h3>{{ template "accountList" .OwnerBLists.Friends }}</div>
-        <div class="cell"><h3>Leaders</h3>{{ template "accountList" .OwnerBLists.Leaders }}</div>
-        <div class="cell"><h3>Groupies</h3>{{ template "accountList" .OwnerBLists.Groupies }}</div>
+    <div class="section-header">
+        <h2>{{ .OwnerB }} — Relationship Matrix</h2>
+        <button type="button" class="section-toggle" data-section-id="owner-b-matrix-content" aria-expanded="true" aria-controls="owner-b-matrix-content">Hide</button>
+    </div>
+    <div class="section-content" id="owner-b-matrix-content">
+        <div class="matrix">
+            <div class="cell"><h3>Friends</h3>{{ template "accountList" .OwnerBLists.Friends }}</div>
+            <div class="cell"><h3>Leaders</h3>{{ template "accountList" .OwnerBLists.Leaders }}</div>
+            <div class="cell"><h3>Groupies</h3>{{ template "accountList" .OwnerBLists.Groupies }}</div>
+        </div>
     </div>
 </section>
 
 <!-- Removed the static “B follows that A doesn’t” section -->
 
 <section id="comparisons">
-    <h2>On-the-fly comparisons</h2>
-    <div>
-        <label for="cmpOp">Operation:</label>
-        <select id="cmpOp">
-            <option value="B_following_minus_A_following">{{ .OwnerB }} follows that {{ .OwnerA }} doesn’t</option>
-            <option value="A_following_minus_B_following">{{ .OwnerA }} follows that {{ .OwnerB }} doesn’t</option>
-            <option value="mutual_following">Mutual following (Friends of {{ .OwnerA }} & {{ .OwnerB }})</option>
-            <option value="A_followers_minus_following">{{ .OwnerA }}’s followers not followed by {{ .OwnerA }}</option>
-            <option value="B_followers_minus_following">{{ .OwnerB }}’s followers not followed by {{ .OwnerB }}</option>
-            <option value="A_blocked_intersect_following">{{ .OwnerA }}: Blocked ∩ Following</option>
-            <option value="B_blocked_intersect_following">{{ .OwnerB }}: Blocked ∩ Following</option>
-            <option value="symdiff_following">Symmetric diff (Following of {{ .OwnerA }} vs {{ .OwnerB }})</option>
-        </select>
-        <button id="runCmp">Run</button>
+    <div class="section-header">
+        <h2>On-the-fly comparisons</h2>
+        <button type="button" class="section-toggle" data-section-id="comparisons-content" aria-expanded="true" aria-controls="comparisons-content">Hide</button>
     </div>
-    <div id="cmpOut" class="cell" style="margin-top:12px"></div>
+    <div class="section-content" id="comparisons-content">
+        <div>
+            <label for="cmpOp">Operation:</label>
+            <select id="cmpOp">
+                <option value="B_following_minus_A_following">{{ .OwnerB }} follows that {{ .OwnerA }} doesn’t</option>
+                <option value="A_following_minus_B_following">{{ .OwnerA }} follows that {{ .OwnerB }} doesn’t</option>
+                <option value="mutual_following">Mutual following (Friends of {{ .OwnerA }} & {{ .OwnerB }})</option>
+                <option value="A_followers_minus_following">{{ .OwnerA }}’s followers not followed by {{ .OwnerA }}</option>
+                <option value="B_followers_minus_following">{{ .OwnerB }}’s followers not followed by {{ .OwnerB }}</option>
+                <option value="A_blocked_intersect_following">{{ .OwnerA }}: Blocked ∩ Following</option>
+                <option value="B_blocked_intersect_following">{{ .OwnerB }}: Blocked ∩ Following</option>
+                <option value="symdiff_following">Symmetric diff (Following of {{ .OwnerA }} vs {{ .OwnerB }})</option>
+            </select>
+            <button id="runCmp">Run</button>
+        </div>
+        <div id="cmpOut" class="cell" style="margin-top:12px"></div>
+    </div>
 </section>
 
 <section id="owner-a-blocked">
-    <h2>Blocked accounts — {{ .OwnerA }}</h2>
-    <h3 class="sub">Also in Following</h3>{{ template "accountList" .OwnerALists.BlockedAndFollowing }}
-    <h3 class="sub">Also in Followers</h3>{{ template "accountList" .OwnerALists.BlockedAndFollowers }}
-    <h3 class="sub">All Blocked</h3>{{ template "accountList" .OwnerALists.BlockedAll }}
+    <div class="section-header">
+        <h2>Blocked accounts — {{ .OwnerA }}</h2>
+        <button type="button" class="section-toggle" data-section-id="owner-a-blocked-content" aria-expanded="true" aria-controls="owner-a-blocked-content">Hide</button>
+    </div>
+    <div class="section-content" id="owner-a-blocked-content">
+        <h3 class="sub">Also in Following</h3>{{ template "accountList" .OwnerALists.BlockedAndFollowing }}
+        <h3 class="sub">Also in Followers</h3>{{ template "accountList" .OwnerALists.BlockedAndFollowers }}
+        <h3 class="sub">All Blocked</h3>{{ template "accountList" .OwnerALists.BlockedAll }}
+    </div>
 </section>
 
 <section id="owner-b-blocked">
-    <h2>Blocked accounts — {{ .OwnerB }}</h2>
-    <h3 class="sub">Also in Following</h3>{{ template "accountList" .OwnerBLists.BlockedAndFollowing }}
-    <h3 class="sub">Also in Followers</h3>{{ template "accountList" .OwnerBLists.BlockedAndFollowers }}
-    <h3 class="sub">All Blocked</h3>{{ template "accountList" .OwnerBLists.BlockedAll }}
+    <div class="section-header">
+        <h2>Blocked accounts — {{ .OwnerB }}</h2>
+        <button type="button" class="section-toggle" data-section-id="owner-b-blocked-content" aria-expanded="true" aria-controls="owner-b-blocked-content">Hide</button>
+    </div>
+    <div class="section-content" id="owner-b-blocked-content">
+        <h3 class="sub">Also in Following</h3>{{ template "accountList" .OwnerBLists.BlockedAndFollowing }}
+        <h3 class="sub">Also in Followers</h3>{{ template "accountList" .OwnerBLists.BlockedAndFollowers }}
+        <h3 class="sub">All Blocked</h3>{{ template "accountList" .OwnerBLists.BlockedAll }}
+    </div>
 </section>
 
 <footer><p>Identity & file paths via manifest.js; follow/blocks/mutes via follower.js, following.js, block.js, mute.js.</p></footer>


### PR DESCRIPTION
## Summary
- add toggle controls beside each major section in the dump comparison template and wrap their contents for collapsing
- introduce styles for the new toggle buttons along with a utility class used to hide collapsed sections
- extend the client script to manage section visibility while updating aria attributes and button labels, and cover the new markup in tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ca22871b508327b804456d13cdcea0