### PR TITLE
Add upload-driven comparison UI with runtime archive handling

### DIFF
--- a/cmd/dump/main.go
+++ b/cmd/dump/main.go
@@ -68,7 +68,7 @@ func main() {
 
 	comparison := matrix.BuildComparison(accountSetsA, accountSetsB, ownerA, ownerB)
 
-	pageHTML, err := matrix.RenderComparisonPage(comparison)
+	pageHTML, err := matrix.RenderComparisonPage(matrix.ComparisonPageData{Comparison: &comparison})
 	if err != nil {
 		dief(renderErrorFormat, err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -20,10 +19,6 @@ const (
 	commandUse                    = "server"
 	commandShortDescription       = "Serve the comparison matrix over HTTP"
 	envPrefix                     = "FSYNC_SERVER"
-	flagZipAName                  = "zip-a"
-	flagZipADescription           = "Path to the first Twitter archive zip"
-	flagZipBName                  = "zip-b"
-	flagZipBDescription           = "Path to the second Twitter archive zip"
 	flagResolveHandlesName        = "resolve-handles"
 	flagResolveHandlesDescription = "Resolve missing handles via HTTPS lookups"
 	flagHostName                  = "host"
@@ -32,19 +27,13 @@ const (
 	flagPortDescription           = "Port for the HTTP server"
 	defaultHost                   = "127.0.0.1"
 	defaultPort                   = 8080
-	errMessageMissingZipFlags     = "both --zip-a and --zip-b must be provided"
 	errMessageLoggerCreate        = "create logger"
-	errMessageReadArchive         = "read archive"
 	errMessageResolverCreate      = "create resolver"
 	errMessageListenAndServe      = "listen and serve"
-	logMessageLoadingArchive      = "loading twitter archive"
 	logMessageResolvingHandles    = "resolving handles"
-	logMessageHandleError         = "handle resolution error"
 	logMessageStartingServer      = "starting HTTP server"
 	logMessageServerStopped       = "server stopped"
 	logMessageListenError         = "server listen failure"
-	logFieldArchivePath           = "archive"
-	logFieldAccountID             = "account_id"
 	logFieldAddress               = "address"
 )
 
@@ -59,14 +48,10 @@ func newServerCommand() *cobra.Command {
 		RunE:  runServerCommand,
 	}
 
-	command.Flags().String(flagZipAName, "", flagZipADescription)
-	command.Flags().String(flagZipBName, "", flagZipBDescription)
 	command.Flags().Bool(flagResolveHandlesName, false, flagResolveHandlesDescription)
 	command.Flags().String(flagHostName, defaultHost, flagHostDescription)
 	command.Flags().Int(flagPortName, defaultPort, flagPortDescription)
 
-	bindFlagToViper(command, flagZipAName)
-	bindFlagToViper(command, flagZipBName)
 	bindFlagToViper(command, flagResolveHandlesName)
 	bindFlagToViper(command, flagHostName)
 	bindFlagToViper(command, flagPortName)
@@ -87,12 +72,6 @@ func configureEnvironment() {
 }
 
 func runServerCommand(*cobra.Command, []string) error {
-	zipPathA := strings.TrimSpace(viper.GetString(flagZipAName))
-	zipPathB := strings.TrimSpace(viper.GetString(flagZipBName))
-	if zipPathA == "" || zipPathB == "" {
-		return fmt.Errorf(errMessageMissingZipFlags)
-	}
-
 	logger, err := zap.NewProduction()
 	if err != nil {
 		return fmt.Errorf("%s: %w", errMessageLoggerCreate, err)
@@ -101,38 +80,20 @@ func runServerCommand(*cobra.Command, []string) error {
 		_ = logger.Sync()
 	}()
 
-	logger.Info(logMessageLoadingArchive, zap.String(logFieldArchivePath, zipPathA))
-	accountSetsA, ownerA, err := matrix.ReadTwitterZip(zipPathA)
-	if err != nil {
-		return fmt.Errorf("%s %s: %w", errMessageReadArchive, zipPathA, err)
-	}
-
-	logger.Info(logMessageLoadingArchive, zap.String(logFieldArchivePath, zipPathB))
-	accountSetsB, ownerB, err := matrix.ReadTwitterZip(zipPathB)
-	if err != nil {
-		return fmt.Errorf("%s %s: %w", errMessageReadArchive, zipPathB, err)
-	}
-
+	var resolver matrix.AccountHandleResolver
 	if viper.GetBool(flagResolveHandlesName) {
 		logger.Info(logMessageResolvingHandles)
-		resolver, err := handles.NewResolver(handles.Config{})
-		if err != nil {
-			return fmt.Errorf("%s: %w", errMessageResolverCreate, err)
+		handlesResolver, resolverErr := handles.NewResolver(handles.Config{})
+		if resolverErr != nil {
+			return fmt.Errorf("%s: %w", errMessageResolverCreate, resolverErr)
 		}
-		resolutionErrors := matrix.MaybeResolveHandles(context.Background(), resolver, true, &accountSetsA, &accountSetsB)
-		for accountID, resolutionErr := range resolutionErrors {
-			logger.Warn(logMessageHandleError, zap.String(logFieldAccountID, accountID), zap.Error(resolutionErr))
-		}
+		resolver = handlesResolver
 	}
 
 	router, err := server.NewRouter(server.RouterConfig{
-		ComparisonData: &server.ComparisonData{
-			AccountSetsA: accountSetsA,
-			AccountSetsB: accountSetsB,
-			OwnerA:       ownerA,
-			OwnerB:       ownerB,
-		},
-		Logger: logger,
+		Logger:         logger,
+		ResolveHandles: viper.GetBool(flagResolveHandlesName),
+		HandleResolver: resolver,
 	})
 	if err != nil {
 		return err

--- a/internal/matrix/assets.go
+++ b/internal/matrix/assets.go
@@ -35,6 +35,11 @@ func embeddedText(path string) (string, error) {
 	return string(content), nil
 }
 
+// StaticAssets exposes the embedded static asset filesystem.
+func StaticAssets() (fs.FS, error) {
+	return fs.Sub(embeddedFS, "web/static")
+}
+
 func parseTemplates(fileSystem fs.FS, files ...string) (*template.Template, error) {
 	templateWithFuncs := template.New(templateBaseName).Funcs(template.FuncMap{
 		"profileURL": func(record AccountRecord) string {

--- a/internal/matrix/models.go
+++ b/internal/matrix/models.go
@@ -49,7 +49,7 @@ type ComparisonResult struct {
 
 // UploadSummary describes an archive that has been uploaded for comparison.
 type UploadSummary struct {
-	SlotLabel  string
-	OwnerLabel string
-	FileName   string
+	SlotLabel  string `json:"slotLabel"`
+	OwnerLabel string `json:"ownerLabel"`
+	FileName   string `json:"fileName"`
 }

--- a/internal/matrix/models.go
+++ b/internal/matrix/models.go
@@ -46,3 +46,10 @@ type ComparisonResult struct {
 	OwnerBBlockedAndFollowing []AccountRecord
 	OwnerBBlockedAndFollowers []AccountRecord
 }
+
+// UploadSummary describes an archive that has been uploaded for comparison.
+type UploadSummary struct {
+	SlotLabel  string
+	OwnerLabel string
+	FileName   string
+}

--- a/internal/matrix/render.go
+++ b/internal/matrix/render.go
@@ -68,9 +68,9 @@ type comparisonPageViewModel struct {
 }
 
 type uploadSummaryViewModel struct {
-	SlotLabel string
-	Owner     string
-	FileName  string
+	SlotLabel  string
+	OwnerLabel string
+	FileName   string
 }
 
 type ownerListViewModel struct {
@@ -179,9 +179,9 @@ func newComparisonPageViewModel(pageData ComparisonPageData, cssText string, jsT
 		viewModel.Uploads = make([]uploadSummaryViewModel, 0, len(pageData.Uploads))
 		for _, upload := range pageData.Uploads {
 			viewModel.Uploads = append(viewModel.Uploads, uploadSummaryViewModel{
-				SlotLabel: upload.SlotLabel,
-				Owner:     upload.OwnerLabel,
-				FileName:  upload.FileName,
+				SlotLabel:  upload.SlotLabel,
+				OwnerLabel: upload.OwnerLabel,
+				FileName:   upload.FileName,
 			})
 		}
 	}

--- a/internal/matrix/render.go
+++ b/internal/matrix/render.go
@@ -8,8 +8,15 @@ import (
 	"strings"
 )
 
+// ComparisonPageData captures the state needed to render the interactive comparison page.
+type ComparisonPageData struct {
+	Comparison *ComparisonResult
+	Uploads    []UploadSummary
+	Errors     []string
+}
+
 // RenderComparisonPage assembles the HTML output using the embedded assets and templates.
-func RenderComparisonPage(comparison ComparisonResult) (string, error) {
+func RenderComparisonPage(pageData ComparisonPageData) (string, error) {
 	cssText, err := embeddedText(embeddedBaseCSSPath)
 	if err != nil {
 		return "", err
@@ -18,11 +25,14 @@ func RenderComparisonPage(comparison ComparisonResult) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	matrixJSON, err := buildMatrixJSON(comparison)
-	if err != nil {
-		return "", err
+	matrixJSON := ""
+	if pageData.Comparison != nil {
+		matrixJSON, err = buildMatrixJSON(*pageData.Comparison)
+		if err != nil {
+			return "", err
+		}
 	}
-	viewModel := newComparisonPageViewModel(comparison, cssText, jsText, matrixJSON)
+	viewModel := newComparisonPageViewModel(pageData, cssText, jsText, matrixJSON)
 	tmpl, err := parseTemplates(embeddedFS, templateIndexFile)
 	if err != nil {
 		return "", fmt.Errorf("template parse: %w", err)
@@ -35,7 +45,8 @@ func RenderComparisonPage(comparison ComparisonResult) (string, error) {
 }
 
 type comparisonPageViewModel struct {
-	Title string
+	Title         string
+	HasComparison bool
 
 	OwnerA string
 	OwnerB string
@@ -48,9 +59,18 @@ type comparisonPageViewModel struct {
 	OwnerALists ownerListViewModel
 	OwnerBLists ownerListViewModel
 
+	Uploads []uploadSummaryViewModel
+	Errors  []string
+
 	MatrixJSON template.JS
 	CSS        template.CSS
 	JS         template.JS
+}
+
+type uploadSummaryViewModel struct {
+	SlotLabel string
+	Owner     string
+	FileName  string
 }
 
 type ownerListViewModel struct {
@@ -144,34 +164,56 @@ func (decorator accountBadgeDecorator) isBlocked(accountID string) bool {
 	return decorator.blockedIDs[accountID]
 }
 
-func newComparisonPageViewModel(comparison ComparisonResult, cssText string, jsText string, matrixJSON string) comparisonPageViewModel {
+func newComparisonPageViewModel(pageData ComparisonPageData, cssText string, jsText string, matrixJSON string) comparisonPageViewModel {
+	viewModel := comparisonPageViewModel{
+		Title: pageTitleText,
+		CSS:   template.CSS(cssText),
+		JS:    template.JS(jsText),
+	}
+
+	if len(pageData.Errors) > 0 {
+		viewModel.Errors = append(viewModel.Errors, pageData.Errors...)
+	}
+
+	if len(pageData.Uploads) > 0 {
+		viewModel.Uploads = make([]uploadSummaryViewModel, 0, len(pageData.Uploads))
+		for _, upload := range pageData.Uploads {
+			viewModel.Uploads = append(viewModel.Uploads, uploadSummaryViewModel{
+				SlotLabel: upload.SlotLabel,
+				Owner:     upload.OwnerLabel,
+				FileName:  upload.FileName,
+			})
+		}
+	}
+
+	if pageData.Comparison == nil {
+		return viewModel
+	}
+
+	comparison := *pageData.Comparison
 	ownerADecorator := newAccountBadgeDecorator(comparison.AccountSetsA.Muted, comparison.AccountSetsA.Blocked)
 	ownerBDecorator := newAccountBadgeDecorator(comparison.AccountSetsB.Muted, comparison.AccountSetsB.Blocked)
 
-	viewModel := comparisonPageViewModel{
-		Title:  pageTitleText,
-		OwnerA: ownerPretty(comparison.OwnerA),
-		OwnerB: ownerPretty(comparison.OwnerB),
-		OwnerALists: ownerListViewModel{
-			Friends:             ownerADecorator.Decorate(comparison.OwnerAFriends),
-			Leaders:             ownerADecorator.Decorate(comparison.OwnerALeaders),
-			Groupies:            ownerADecorator.Decorate(comparison.OwnerAGroupies),
-			BlockedAll:          ownerADecorator.Decorate(comparison.OwnerABlockedAll),
-			BlockedAndFollowing: ownerADecorator.Decorate(comparison.OwnerABlockedAndFollowing),
-			BlockedAndFollowers: ownerADecorator.Decorate(comparison.OwnerABlockedAndFollowers),
-		},
-		OwnerBLists: ownerListViewModel{
-			Friends:             ownerBDecorator.Decorate(comparison.OwnerBFriends),
-			Leaders:             ownerBDecorator.Decorate(comparison.OwnerBLeaders),
-			Groupies:            ownerBDecorator.Decorate(comparison.OwnerBGroupies),
-			BlockedAll:          ownerBDecorator.Decorate(comparison.OwnerBBlockedAll),
-			BlockedAndFollowing: ownerBDecorator.Decorate(comparison.OwnerBBlockedAndFollowing),
-			BlockedAndFollowers: ownerBDecorator.Decorate(comparison.OwnerBBlockedAndFollowers),
-		},
-		MatrixJSON: template.JS(matrixJSON),
-		CSS:        template.CSS(cssText),
-		JS:         template.JS(jsText),
+	viewModel.HasComparison = true
+	viewModel.OwnerA = ownerPretty(comparison.OwnerA)
+	viewModel.OwnerB = ownerPretty(comparison.OwnerB)
+	viewModel.OwnerALists = ownerListViewModel{
+		Friends:             ownerADecorator.Decorate(comparison.OwnerAFriends),
+		Leaders:             ownerADecorator.Decorate(comparison.OwnerALeaders),
+		Groupies:            ownerADecorator.Decorate(comparison.OwnerAGroupies),
+		BlockedAll:          ownerADecorator.Decorate(comparison.OwnerABlockedAll),
+		BlockedAndFollowing: ownerADecorator.Decorate(comparison.OwnerABlockedAndFollowing),
+		BlockedAndFollowers: ownerADecorator.Decorate(comparison.OwnerABlockedAndFollowers),
 	}
+	viewModel.OwnerBLists = ownerListViewModel{
+		Friends:             ownerBDecorator.Decorate(comparison.OwnerBFriends),
+		Leaders:             ownerBDecorator.Decorate(comparison.OwnerBLeaders),
+		Groupies:            ownerBDecorator.Decorate(comparison.OwnerBGroupies),
+		BlockedAll:          ownerBDecorator.Decorate(comparison.OwnerBBlockedAll),
+		BlockedAndFollowing: ownerBDecorator.Decorate(comparison.OwnerBBlockedAndFollowing),
+		BlockedAndFollowers: ownerBDecorator.Decorate(comparison.OwnerBBlockedAndFollowers),
+	}
+	viewModel.MatrixJSON = template.JS(matrixJSON)
 	viewModel.Counts.A.Followers = len(comparison.OwnerAFollowersAll)
 	viewModel.Counts.A.Following = len(comparison.OwnerAFollowingsAll)
 	viewModel.Counts.A.Friends = len(comparison.OwnerAFriends)

--- a/internal/matrix/render_test.go
+++ b/internal/matrix/render_test.go
@@ -7,96 +7,69 @@ import (
 	"github.com/f-sync/fsync/internal/matrix"
 )
 
-func TestRenderComparisonPageStructure(t *testing.T) {
-	const (
-		snippetAccountCard           = "class=\"account-card\""
-		snippetAccountDisplay        = "<strong class=\"account-display\">Muted Blocked</strong>"
-		snippetAccountHandle         = "<span class=\"account-handle\">@presented</span>"
-		snippetMutedBadge            = "<span class=\"badge badge-muted\">Muted</span>"
-		snippetBlockedBadge          = "<span class=\"badge badge-block\">Blocked</span>"
-		snippetEmbeddedCSSClass      = ".account-card-link:hover .account-display {"
-		snippetEmptyPlaceholder      = "<p class=\"muted\">None</p>"
-		snippetTableOfContentsNav    = "<nav class=\"toc\" aria-label=\"Page sections\">"
-		snippetTableOfContentsAnchor = "<a class=\"toc-link\" href=\"#overview\">Overview</a>"
-		snippetSectionToggleControl  = "<button type=\"button\" class=\"section-toggle\" data-section-id=\"overview-content\" aria-expanded=\"true\" aria-controls=\"overview-content\">Hide</button>"
-		snippetSectionContent        = "<div class=\"section-content\" id=\"overview-content\">"
-	)
-
-	decoratedRecord := matrix.AccountRecord{AccountID: "42", UserName: "presented", DisplayName: "Muted Blocked"}
-
-	testCases := []struct {
-		name             string
-		comparison       matrix.ComparisonResult
-		expectedSnippets []string
-	}{
-		{
-			name: "renders account cards with badges",
-			comparison: matrix.ComparisonResult{
-				AccountSetsA: matrix.AccountSets{
-					Followers: map[string]matrix.AccountRecord{"42": decoratedRecord},
-					Following: map[string]matrix.AccountRecord{"42": decoratedRecord},
-					Muted:     map[string]bool{"42": true},
-					Blocked:   map[string]bool{"42": true},
-				},
-				AccountSetsB:        matrix.AccountSets{Muted: map[string]bool{}, Blocked: map[string]bool{}},
-				OwnerA:              matrix.OwnerIdentity{AccountID: "1", UserName: "owner_a", DisplayName: "Owner A"},
-				OwnerB:              matrix.OwnerIdentity{AccountID: "2", UserName: "owner_b", DisplayName: "Owner B"},
-				OwnerAFriends:       []matrix.AccountRecord{decoratedRecord},
-				OwnerABlockedAll:    []matrix.AccountRecord{decoratedRecord},
-				OwnerAFollowersAll:  []matrix.AccountRecord{decoratedRecord},
-				OwnerAFollowingsAll: []matrix.AccountRecord{decoratedRecord},
-			},
-			expectedSnippets: []string{
-				snippetAccountCard,
-				snippetAccountDisplay,
-				snippetAccountHandle,
-				snippetMutedBadge,
-				snippetBlockedBadge,
-				snippetEmbeddedCSSClass,
-				snippetTableOfContentsNav,
-				snippetTableOfContentsAnchor,
-				snippetSectionToggleControl,
-				snippetSectionContent,
-			},
-		},
-		{
-			name: "renders placeholder for empty lists",
-			comparison: matrix.ComparisonResult{
-				AccountSetsA: matrix.AccountSets{
-					Followers: map[string]matrix.AccountRecord{},
-					Following: map[string]matrix.AccountRecord{},
-					Muted:     map[string]bool{},
-					Blocked:   map[string]bool{},
-				},
-				AccountSetsB: matrix.AccountSets{
-					Followers: map[string]matrix.AccountRecord{},
-					Following: map[string]matrix.AccountRecord{},
-					Muted:     map[string]bool{},
-					Blocked:   map[string]bool{},
-				},
-			},
-			expectedSnippets: []string{
-				snippetEmptyPlaceholder,
-				snippetTableOfContentsNav,
-				snippetTableOfContentsAnchor,
-				snippetSectionToggleControl,
-				snippetSectionContent,
-			},
+func TestRenderComparisonPageRendersUploadInterface(t *testing.T) {
+	pageData := matrix.ComparisonPageData{
+		Uploads: []matrix.UploadSummary{
+			{SlotLabel: "Archive A", OwnerLabel: "Owner Alpha", FileName: "alpha.zip"},
+			{SlotLabel: "Archive B", OwnerLabel: "Owner Beta", FileName: "beta.zip"},
 		},
 	}
 
-	for _, testCase := range testCases {
-		testCase := testCase
-		t.Run(testCase.name, func(t *testing.T) {
-			html, err := matrix.RenderComparisonPage(testCase.comparison)
-			if err != nil {
-				t.Fatalf("RenderComparisonPage: %v", err)
-			}
-			for _, snippet := range testCase.expectedSnippets {
-				if !strings.Contains(html, snippet) {
-					t.Fatalf("expected HTML to contain %q", snippet)
-				}
-			}
-		})
+	html, err := matrix.RenderComparisonPage(pageData)
+	if err != nil {
+		t.Fatalf("RenderComparisonPage returned error: %v", err)
+	}
+
+	expectedSnippets := []string{
+		"id=\"archiveDropzone\"",
+		"Upload two archives and press <strong>Compare</strong>",
+		"Owner Alpha",
+		"data-has-comparison=\"false\"",
+	}
+	for _, snippet := range expectedSnippets {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("expected HTML to contain %q", snippet)
+		}
+	}
+}
+
+func TestRenderComparisonPageWithComparisonData(t *testing.T) {
+	decoratedRecord := matrix.AccountRecord{AccountID: "42", UserName: "presented", DisplayName: "Muted Blocked"}
+	comparison := matrix.ComparisonResult{
+		AccountSetsA: matrix.AccountSets{
+			Followers: map[string]matrix.AccountRecord{"42": decoratedRecord},
+			Following: map[string]matrix.AccountRecord{"42": decoratedRecord},
+			Muted:     map[string]bool{"42": true},
+			Blocked:   map[string]bool{"42": true},
+		},
+		AccountSetsB:        matrix.AccountSets{Muted: map[string]bool{}, Blocked: map[string]bool{}},
+		OwnerA:              matrix.OwnerIdentity{AccountID: "1", UserName: "owner_a", DisplayName: "Owner A"},
+		OwnerB:              matrix.OwnerIdentity{AccountID: "2", UserName: "owner_b", DisplayName: "Owner B"},
+		OwnerAFriends:       []matrix.AccountRecord{decoratedRecord},
+		OwnerABlockedAll:    []matrix.AccountRecord{decoratedRecord},
+		OwnerAFollowersAll:  []matrix.AccountRecord{decoratedRecord},
+		OwnerAFollowingsAll: []matrix.AccountRecord{decoratedRecord},
+	}
+
+	pageData := matrix.ComparisonPageData{
+		Comparison: &comparison,
+		Uploads:    []matrix.UploadSummary{{SlotLabel: "Archive A", OwnerLabel: "Owner A", FileName: "a.zip"}},
+	}
+
+	html, err := matrix.RenderComparisonPage(pageData)
+	if err != nil {
+		t.Fatalf("RenderComparisonPage returned error: %v", err)
+	}
+
+	expectedSnippets := []string{
+		"nav class=\"nav nav-pills",
+		"Owner A (@owner_a) — Relationship Matrix",
+		"badge text-bg-danger\">Blocked</span>",
+		"data-has-comparison=\"true\"",
+	}
+	for _, snippet := range expectedSnippets {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("expected HTML to contain %q", snippet)
+		}
 	}
 }

--- a/internal/matrix/web/static/base.css
+++ b/internal/matrix/web/static/base.css
@@ -1,260 +1,52 @@
+@import url("https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/materia/bootstrap.min.css");
+
 body {
-    font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, sans-serif;
-    margin: 24px;
-    line-height: 1.45
+    background-color: #f5f7fa;
 }
 
-h1, h2, h3 {
-    margin: 0 0 12px
+.navbar {
+    backdrop-filter: blur(6px);
 }
 
-header p, footer p {
-    color: #555
+.upload-dropzone {
+    background-color: rgba(33, 150, 243, 0.08);
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
-.toc {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    margin: 24px 0;
-    padding: 16px;
-    border: 1px solid #e0e0e0;
-    border-radius: 12px;
-    background: #f9fafb
+.upload-dropzone:focus {
+    outline: none;
+    box-shadow: 0 0 0 0.25rem rgba(33, 150, 243, 0.25);
 }
 
-.toc-title {
-    margin: 0;
-    font-size: 16px;
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    text-transform: uppercase;
-    color: #333
+.upload-dropzone.is-dragover {
+    background-color: rgba(33, 150, 243, 0.18);
+    border-color: #1565c0 !important;
+    transform: translateY(-2px);
 }
 
-.toc-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin: 0;
-    padding: 0;
-    list-style: none
-}
-
-.toc-item {
-    margin: 0
-}
-
-.toc-link {
-    display: inline-block;
-    padding: 6px 12px;
-    border-radius: 999px;
-    border: 1px solid #d0d7de;
-    background: #fff;
-    color: #1c1c1c;
-    font-size: 14px;
-    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease
-}
-
-.toc-link:hover,
-.toc-link:focus {
-    background: #1c1c1c;
-    color: #fff;
-    border-color: #1c1c1c;
-    text-decoration: none
-}
-
-section {
-    scroll-margin-top: 80px
-}
-
-.section-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    margin-bottom: 12px
+.border-dashed {
+    border-style: dashed !important;
 }
 
 .section-toggle {
-    padding: 6px 12px;
-    border: 1px solid #d0d7de;
-    border-radius: 999px;
-    background: #fff;
-    color: #1c1c1c;
-    font-size: 12px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease
-}
-
-.section-toggle:hover,
-.section-toggle:focus {
-    background: #1c1c1c;
-    color: #fff;
-    border-color: #1c1c1c;
-    outline: none
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
 }
 
 .section-content.is-hidden {
-    display: none
+    display: none;
 }
 
-.is-hidden {
-    display: none !important
+#cmpOut ul {
+    padding-left: 1rem;
 }
 
-.grid {
-    display: grid;
-    grid-template-columns:1fr 1fr;
-    gap: 16px
+#cmpOut li {
+    margin-bottom: 0.75rem;
 }
 
-.matrix {
-    display: grid;
-    grid-template-columns:1fr 1fr 1fr;
-    gap: 16px
-}
-
-.cell {
-    border: 1px solid #ddd;
-    border-radius: 8px;
-    padding: 12px;
-    min-height: 80px
-}
-
-.sub {
-    margin: 16px 0 8px 0
-}
-
-ul {
-    margin: 8px 0 0 0;
-    padding: 0;
-    list-style: none
-}
-
-.account-list {
-    margin-top: 12px
-}
-
-.account-card {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 4px;
-    padding: 10px 0;
-    border-bottom: 1px solid #e6e6e6
-}
-
-.account-card:last-child {
-    border-bottom: none
-}
-
-.account-card-main {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    width: 100%
-}
-
-.account-card-link {
-    color: inherit;
-    text-decoration: none
-}
-
-.account-card-link:hover .account-display {
-    text-decoration: underline
-}
-
-.account-display {
-    font-weight: 600;
-    font-size: 14px;
-    color: #1c1c1c
-}
-
-.account-handle {
-    font-size: 12px;
-    color: #5f6368
-}
-
-.account-meta {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 8px;
-    font-size: 11px;
-    color: #333
-}
-
-a {
-    text-decoration: none
-}
-
-a:hover {
-    text-decoration: underline
-}
-
-.btn {
-    display: inline-block;
-    padding: 2px 8px;
-    border: 1px solid #ccc;
-    border-radius: 12px;
-    font-size: 12px;
-    text-decoration: none
-}
-
-.btn:hover {
-    background: #f5f5f5
-}
-
-.account-meta .btn {
-    margin-left: 0
-}
-
-.muted {
-    color: #777;
-    font-size: 12px
-}
-
-.badge {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 999px;
-    font-size: 11px;
-    font-weight: 600;
-    background: #f2f3f5;
-    color: #333
-}
-
-.badge-muted {
-    background: #e8edff;
-    color: #4257b2
-}
-
-.badge-block {
-    background: #fde8e7;
-    color: #b42318
-}
-
-@media (max-width: 700px) {
-    .toc {
-        padding: 12px;
-        gap: 10px
-    }
-
-    .toc-list {
-        flex-direction: column;
-        gap: 6px
-    }
-
-    .toc-link {
-        width: 100%;
-        text-align: center
-    }
-}
-
-@media (max-width: 900px) {
-    .grid, .matrix {
-        grid-template-columns:1fr
-    }
+footer {
+    margin-top: 4rem;
 }

--- a/internal/matrix/web/templates/index.tmpl
+++ b/internal/matrix/web/templates/index.tmpl
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8">
     <title>{{ .Title }}</title>
@@ -7,148 +7,272 @@
     <style>{{ .CSS }}</style>
 </head>
 <body>
-<header>
-    <h1>Twitter Relationship Matrix</h1>
-    <p>Offline analysis from two archives. No API calls.</p>
-</header>
-
-<nav class="toc" aria-label="Page sections">
-    <h2 class="toc-title">Jump to section</h2>
-    <ul class="toc-list">
-        <li class="toc-item"><a class="toc-link" href="#overview">Overview</a></li>
-        <li class="toc-item"><a class="toc-link" href="#owner-a-matrix">{{ .OwnerA }} — Matrix</a></li>
-        <li class="toc-item"><a class="toc-link" href="#owner-b-matrix">{{ .OwnerB }} — Matrix</a></li>
-        <li class="toc-item"><a class="toc-link" href="#comparisons">Comparisons</a></li>
-        <li class="toc-item"><a class="toc-link" href="#owner-a-blocked">{{ .OwnerA }} — Blocked</a></li>
-        <li class="toc-item"><a class="toc-link" href="#owner-b-blocked">{{ .OwnerB }} — Blocked</a></li>
-    </ul>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
+    <div class="container">
+        <span class="navbar-brand fw-semibold">Twitter Relationship Matrix</span>
+    </div>
 </nav>
 
-<section id="overview">
-    <div class="section-header">
-        <h2>Overview</h2>
-        <button type="button" class="section-toggle" data-section-id="overview-content" aria-expanded="true" aria-controls="overview-content">Hide</button>
-    </div>
-    <div class="section-content" id="overview-content">
-        <div class="grid">
-            <div>
-                <h3>{{ .OwnerA }}</h3>
-                <ul>
-                    <li>Followers: {{ .Counts.A.Followers }}</li>
-                    <li>Followings: {{ .Counts.A.Following }}</li>
-                    <li>Friends: {{ .Counts.A.Friends }}</li>
-                    <li>Leaders: {{ .Counts.A.Leaders }}</li>
-                    <li>Groupies: {{ .Counts.A.Groupies }}</li>
-                    <li>Muted: {{ .Counts.A.Muted }}</li>
-                    <li>Blocked: {{ .Counts.A.Blocked }}</li>
-                </ul>
-            </div>
-            <div>
-                <h3>{{ .OwnerB }}</h3>
-                <ul>
-                    <li>Followers: {{ .Counts.B.Followers }}</li>
-                    <li>Followings: {{ .Counts.B.Following }}</li>
-                    <li>Friends: {{ .Counts.B.Friends }}</li>
-                    <li>Leaders: {{ .Counts.B.Leaders }}</li>
-                    <li>Groupies: {{ .Counts.B.Groupies }}</li>
-                    <li>Muted: {{ .Counts.B.Muted }}</li>
-                    <li>Blocked: {{ .Counts.B.Blocked }}</li>
-                </ul>
-            </div>
+<main class="container my-4">
+    <div class="row g-4 align-items-stretch">
+        <div class="col-lg-4">
+            <section class="card shadow-sm h-100">
+                <div class="card-header bg-primary bg-opacity-10">
+                    <h1 class="h5 mb-0 text-primary">Upload Twitter archives</h1>
+                </div>
+                <div class="card-body">
+                    <p class="text-muted">Drag and drop up to two ZIP files or browse to upload. Archives remain on this device.</p>
+                    <div id="uploadAlerts">
+                        {{ range .Errors }}
+                            <div class="alert alert-danger" role="alert">{{ . }}</div>
+                        {{ end }}
+                    </div>
+                    <div id="archiveDropzone" class="upload-dropzone border border-primary border-2 border-dashed rounded-4 text-center py-4 px-3 mb-3" tabindex="0" role="button" aria-label="Twitter archive upload dropzone">
+                        <p class="lead mb-3">Drop archives here</p>
+                        <p class="text-muted small mb-4">Accepted format: Twitter ZIP export</p>
+                        <button type="button" class="btn btn-primary" id="browseArchivesButton">Browse files</button>
+                        <input type="file" id="archiveInput" class="d-none" multiple accept=".zip">
+                    </div>
+                    <h2 class="h6 text-uppercase text-muted">Uploaded archives</h2>
+                    <ul class="list-group" id="uploadsList">
+                        {{ if .Uploads }}
+                            {{ range .Uploads }}
+                                <li class="list-group-item">
+                                    <div class="d-flex flex-column">
+                                        <span class="badge bg-info text-dark align-self-start mb-2">{{ .SlotLabel }}</span>
+                                        <span class="fw-semibold">{{ .Owner }}</span>
+                                        <span class="text-muted small">{{ .FileName }}</span>
+                                    </div>
+                                </li>
+                            {{ end }}
+                        {{ else }}
+                            <li class="list-group-item text-muted" id="uploadsPlaceholder">No archives uploaded yet.</li>
+                        {{ end }}
+                    </ul>
+                    <div class="d-flex gap-2 mt-3">
+                        <button type="button" class="btn btn-success flex-grow-1" id="compareButton" disabled>Compare</button>
+                        <button type="button" class="btn btn-outline-secondary" id="resetUploadsButton">Reset</button>
+                    </div>
+                </div>
+            </section>
+        </div>
+        <div class="col-lg-8">
+            <section class="card shadow-sm h-100">
+                <div class="card-header bg-primary bg-opacity-10 d-flex align-items-center justify-content-between">
+                    <h2 class="h5 mb-0 text-primary">Comparison</h2>
+                    {{ if .HasComparison }}
+                        <span class="badge bg-success-subtle text-success">Ready</span>
+                    {{ else }}
+                        <span class="badge bg-secondary text-light">Awaiting uploads</span>
+                    {{ end }}
+                </div>
+                <div class="card-body" id="comparisonPanel" data-has-comparison="{{ if .HasComparison }}true{{ else }}false{{ end }}">
+                    {{ if .HasComparison }}
+                        <nav class="nav nav-pills flex-wrap gap-2 mb-4" aria-label="Comparison sections">
+                            <a class="btn btn-outline-primary" href="#overview">Overview</a>
+                            <a class="btn btn-outline-primary" href="#owner-a-matrix">{{ .OwnerA }} — Matrix</a>
+                            <a class="btn btn-outline-primary" href="#owner-b-matrix">{{ .OwnerB }} — Matrix</a>
+                            <a class="btn btn-outline-primary" href="#comparisons">Comparisons</a>
+                            <a class="btn btn-outline-primary" href="#owner-a-blocked">{{ .OwnerA }} — Blocked</a>
+                            <a class="btn btn-outline-primary" href="#owner-b-blocked">{{ .OwnerB }} — Blocked</a>
+                        </nav>
+
+                        <section id="overview" class="mb-4">
+                            <div class="d-flex justify-content-between align-items-center mb-3">
+                                <h3 class="h5 mb-0">Overview</h3>
+                                <button type="button" class="btn btn-sm btn-outline-primary section-toggle" data-section-id="overview-content" aria-expanded="true" aria-controls="overview-content">Hide</button>
+                            </div>
+                            <div id="overview-content" class="section-content">
+                                <div class="row row-cols-1 row-cols-md-2 g-3">
+                                    <div class="col">
+                                        <div class="card border-0 bg-light">
+                                            <div class="card-body">
+                                                <h4 class="h6 text-uppercase text-muted">{{ .OwnerA }}</h4>
+                                                <ul class="list-unstyled mb-0">
+                                                    <li><strong>Followers:</strong> {{ .Counts.A.Followers }}</li>
+                                                    <li><strong>Followings:</strong> {{ .Counts.A.Following }}</li>
+                                                    <li><strong>Friends:</strong> {{ .Counts.A.Friends }}</li>
+                                                    <li><strong>Leaders:</strong> {{ .Counts.A.Leaders }}</li>
+                                                    <li><strong>Groupies:</strong> {{ .Counts.A.Groupies }}</li>
+                                                    <li><strong>Muted:</strong> {{ .Counts.A.Muted }}</li>
+                                                    <li><strong>Blocked:</strong> {{ .Counts.A.Blocked }}</li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col">
+                                        <div class="card border-0 bg-light">
+                                            <div class="card-body">
+                                                <h4 class="h6 text-uppercase text-muted">{{ .OwnerB }}</h4>
+                                                <ul class="list-unstyled mb-0">
+                                                    <li><strong>Followers:</strong> {{ .Counts.B.Followers }}</li>
+                                                    <li><strong>Followings:</strong> {{ .Counts.B.Following }}</li>
+                                                    <li><strong>Friends:</strong> {{ .Counts.B.Friends }}</li>
+                                                    <li><strong>Leaders:</strong> {{ .Counts.B.Leaders }}</li>
+                                                    <li><strong>Groupies:</strong> {{ .Counts.B.Groupies }}</li>
+                                                    <li><strong>Muted:</strong> {{ .Counts.B.Muted }}</li>
+                                                    <li><strong>Blocked:</strong> {{ .Counts.B.Blocked }}</li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
+
+                        <section id="owner-a-matrix" class="mb-4">
+                            <div class="d-flex justify-content-between align-items-center mb-3">
+                                <h3 class="h5 mb-0">{{ .OwnerA }} — Relationship Matrix</h3>
+                                <button type="button" class="btn btn-sm btn-outline-primary section-toggle" data-section-id="owner-a-matrix-content" aria-expanded="true" aria-controls="owner-a-matrix-content">Hide</button>
+                            </div>
+                            <div id="owner-a-matrix-content" class="section-content">
+                                <div class="row row-cols-1 row-cols-md-3 g-3">
+                                    <div class="col">
+                                        <div class="card border-0 bg-light h-100">
+                                            <div class="card-body">
+                                                <h4 class="h6">Friends</h4>
+                                                {{ template "accountList" .OwnerALists.Friends }}
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col">
+                                        <div class="card border-0 bg-light h-100">
+                                            <div class="card-body">
+                                                <h4 class="h6">Leaders</h4>
+                                                {{ template "accountList" .OwnerALists.Leaders }}
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col">
+                                        <div class="card border-0 bg-light h-100">
+                                            <div class="card-body">
+                                                <h4 class="h6">Groupies</h4>
+                                                {{ template "accountList" .OwnerALists.Groupies }}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
+
+                        <section id="owner-b-matrix" class="mb-4">
+                            <div class="d-flex justify-content-between align-items-center mb-3">
+                                <h3 class="h5 mb-0">{{ .OwnerB }} — Relationship Matrix</h3>
+                                <button type="button" class="btn btn-sm btn-outline-primary section-toggle" data-section-id="owner-b-matrix-content" aria-expanded="true" aria-controls="owner-b-matrix-content">Hide</button>
+                            </div>
+                            <div id="owner-b-matrix-content" class="section-content">
+                                <div class="row row-cols-1 row-cols-md-3 g-3">
+                                    <div class="col">
+                                        <div class="card border-0 bg-light h-100">
+                                            <div class="card-body">
+                                                <h4 class="h6">Friends</h4>
+                                                {{ template "accountList" .OwnerBLists.Friends }}
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col">
+                                        <div class="card border-0 bg-light h-100">
+                                            <div class="card-body">
+                                                <h4 class="h6">Leaders</h4>
+                                                {{ template "accountList" .OwnerBLists.Leaders }}
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col">
+                                        <div class="card border-0 bg-light h-100">
+                                            <div class="card-body">
+                                                <h4 class="h6">Groupies</h4>
+                                                {{ template "accountList" .OwnerBLists.Groupies }}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
+
+                        <section id="comparisons" class="mb-4">
+                            <div class="d-flex justify-content-between align-items-center mb-3">
+                                <h3 class="h5 mb-0">On-the-fly comparisons</h3>
+                                <button type="button" class="btn btn-sm btn-outline-primary section-toggle" data-section-id="comparisons-content" aria-expanded="true" aria-controls="comparisons-content">Hide</button>
+                            </div>
+                            <div id="comparisons-content" class="section-content">
+                                <div class="row g-3 align-items-end">
+                                        <div class="col-lg-8">
+                                                <label for="cmpOp" class="form-label">Operation</label>
+                                                <select id="cmpOp" class="form-select">
+                                                        <option value="B_following_minus_A_following">{{ .OwnerB }} follows that {{ .OwnerA }} doesn’t</option>
+                                                        <option value="A_following_minus_B_following">{{ .OwnerA }} follows that {{ .OwnerB }} doesn’t</option>
+                                                        <option value="mutual_following">Mutual following (Friends of {{ .OwnerA }} & {{ .OwnerB }})</option>
+                                                        <option value="A_followers_minus_following">{{ .OwnerA }}’s followers not followed by {{ .OwnerA }}</option>
+                                                        <option value="B_followers_minus_following">{{ .OwnerB }}’s followers not followed by {{ .OwnerB }}</option>
+                                                        <option value="A_blocked_intersect_following">{{ .OwnerA }}: Blocked ∩ Following</option>
+                                                        <option value="B_blocked_intersect_following">{{ .OwnerB }}: Blocked ∩ Following</option>
+                                                        <option value="symdiff_following">Symmetric diff (Following of {{ .OwnerA }} vs {{ .OwnerB }})</option>
+                                                </select>
+                                        </div>
+                                        <div class="col-lg-4 d-grid">
+                                                <button id="runCmp" class="btn btn-primary">Run comparison</button>
+                                        </div>
+                                </div>
+                                <div id="cmpOut" class="card border-0 bg-light mt-3 p-3"></div>
+                            </div>
+                        </section>
+
+                        <section id="owner-a-blocked" class="mb-4">
+                            <div class="d-flex justify-content-between align-items-center mb-3">
+                                <h3 class="h5 mb-0">Blocked accounts — {{ .OwnerA }}</h3>
+                                <button type="button" class="btn btn-sm btn-outline-primary section-toggle" data-section-id="owner-a-blocked-content" aria-expanded="true" aria-controls="owner-a-blocked-content">Hide</button>
+                            </div>
+                            <div id="owner-a-blocked-content" class="section-content">
+                                <h4 class="h6 text-muted">Also in Following</h4>
+                                {{ template "accountList" .OwnerALists.BlockedAndFollowing }}
+                                <h4 class="h6 text-muted mt-3">Also in Followers</h4>
+                                {{ template "accountList" .OwnerALists.BlockedAndFollowers }}
+                                <h4 class="h6 text-muted mt-3">All Blocked</h4>
+                                {{ template "accountList" .OwnerALists.BlockedAll }}
+                            </div>
+                        </section>
+
+                        <section id="owner-b-blocked" class="mb-4">
+                            <div class="d-flex justify-content-between align-items-center mb-3">
+                                <h3 class="h5 mb-0">Blocked accounts — {{ .OwnerB }}</h3>
+                                <button type="button" class="btn btn-sm btn-outline-primary section-toggle" data-section-id="owner-b-blocked-content" aria-expanded="true" aria-controls="owner-b-blocked-content">Hide</button>
+                            </div>
+                            <div id="owner-b-blocked-content" class="section-content">
+                                <h4 class="h6 text-muted">Also in Following</h4>
+                                {{ template "accountList" .OwnerBLists.BlockedAndFollowing }}
+                                <h4 class="h6 text-muted mt-3">Also in Followers</h4>
+                                {{ template "accountList" .OwnerBLists.BlockedAndFollowers }}
+                                <h4 class="h6 text-muted mt-3">All Blocked</h4>
+                                {{ template "accountList" .OwnerBLists.BlockedAll }}
+                            </div>
+                        </section>
+                    {{ else }}
+                        <div class="alert alert-info" role="status">
+                            Upload two archives and press <strong>Compare</strong> to generate the relationship matrix.
+                        </div>
+                    {{ end }}
+                </div>
+            </section>
         </div>
     </div>
-</section>
+</main>
 
-<section id="owner-a-matrix">
-    <div class="section-header">
-        <h2>{{ .OwnerA }} — Relationship Matrix</h2>
-        <button type="button" class="section-toggle" data-section-id="owner-a-matrix-content" aria-expanded="true" aria-controls="owner-a-matrix-content">Hide</button>
+<footer class="bg-dark text-light py-3 mt-auto">
+    <div class="container small text-center">
+        Data sourced from local Twitter archives; no information leaves your browser.
     </div>
-    <div class="section-content" id="owner-a-matrix-content">
-        <div class="matrix">
-            <div class="cell"><h3>Friends</h3>{{ template "accountList" .OwnerALists.Friends }}</div>
-            <div class="cell"><h3>Leaders</h3>{{ template "accountList" .OwnerALists.Leaders }}</div>
-            <div class="cell"><h3>Groupies</h3>{{ template "accountList" .OwnerALists.Groupies }}</div>
-        </div>
-    </div>
-</section>
+</footer>
 
-<section id="owner-b-matrix">
-    <div class="section-header">
-        <h2>{{ .OwnerB }} — Relationship Matrix</h2>
-        <button type="button" class="section-toggle" data-section-id="owner-b-matrix-content" aria-expanded="true" aria-controls="owner-b-matrix-content">Hide</button>
-    </div>
-    <div class="section-content" id="owner-b-matrix-content">
-        <div class="matrix">
-            <div class="cell"><h3>Friends</h3>{{ template "accountList" .OwnerBLists.Friends }}</div>
-            <div class="cell"><h3>Leaders</h3>{{ template "accountList" .OwnerBLists.Leaders }}</div>
-            <div class="cell"><h3>Groupies</h3>{{ template "accountList" .OwnerBLists.Groupies }}</div>
-        </div>
-    </div>
-</section>
-
-<!-- Removed the static “B follows that A doesn’t” section -->
-
-<section id="comparisons">
-    <div class="section-header">
-        <h2>On-the-fly comparisons</h2>
-        <button type="button" class="section-toggle" data-section-id="comparisons-content" aria-expanded="true" aria-controls="comparisons-content">Hide</button>
-    </div>
-    <div class="section-content" id="comparisons-content">
-        <div>
-            <label for="cmpOp">Operation:</label>
-            <select id="cmpOp">
-                <option value="B_following_minus_A_following">{{ .OwnerB }} follows that {{ .OwnerA }} doesn’t</option>
-                <option value="A_following_minus_B_following">{{ .OwnerA }} follows that {{ .OwnerB }} doesn’t</option>
-                <option value="mutual_following">Mutual following (Friends of {{ .OwnerA }} & {{ .OwnerB }})</option>
-                <option value="A_followers_minus_following">{{ .OwnerA }}’s followers not followed by {{ .OwnerA }}</option>
-                <option value="B_followers_minus_following">{{ .OwnerB }}’s followers not followed by {{ .OwnerB }}</option>
-                <option value="A_blocked_intersect_following">{{ .OwnerA }}: Blocked ∩ Following</option>
-                <option value="B_blocked_intersect_following">{{ .OwnerB }}: Blocked ∩ Following</option>
-                <option value="symdiff_following">Symmetric diff (Following of {{ .OwnerA }} vs {{ .OwnerB }})</option>
-            </select>
-            <button id="runCmp">Run</button>
-        </div>
-        <div id="cmpOut" class="cell" style="margin-top:12px"></div>
-    </div>
-</section>
-
-<section id="owner-a-blocked">
-    <div class="section-header">
-        <h2>Blocked accounts — {{ .OwnerA }}</h2>
-        <button type="button" class="section-toggle" data-section-id="owner-a-blocked-content" aria-expanded="true" aria-controls="owner-a-blocked-content">Hide</button>
-    </div>
-    <div class="section-content" id="owner-a-blocked-content">
-        <h3 class="sub">Also in Following</h3>{{ template "accountList" .OwnerALists.BlockedAndFollowing }}
-        <h3 class="sub">Also in Followers</h3>{{ template "accountList" .OwnerALists.BlockedAndFollowers }}
-        <h3 class="sub">All Blocked</h3>{{ template "accountList" .OwnerALists.BlockedAll }}
-    </div>
-</section>
-
-<section id="owner-b-blocked">
-    <div class="section-header">
-        <h2>Blocked accounts — {{ .OwnerB }}</h2>
-        <button type="button" class="section-toggle" data-section-id="owner-b-blocked-content" aria-expanded="true" aria-controls="owner-b-blocked-content">Hide</button>
-    </div>
-    <div class="section-content" id="owner-b-blocked-content">
-        <h3 class="sub">Also in Following</h3>{{ template "accountList" .OwnerBLists.BlockedAndFollowing }}
-        <h3 class="sub">Also in Followers</h3>{{ template "accountList" .OwnerBLists.BlockedAndFollowers }}
-        <h3 class="sub">All Blocked</h3>{{ template "accountList" .OwnerBLists.BlockedAll }}
-    </div>
-</section>
-
-<footer><p>Identity & file paths via manifest.js; follow/blocks/mutes via follower.js, following.js, block.js, mute.js.</p></footer>
-
-<!-- Data blob for JS (keeps JS code generic) -->
 <script id="matrixData" type="application/json">{{ .MatrixJSON }}</script>
 <script>{{ .JS }}</script>
 
 {{ define "accountList" }}
     {{ $entries := . }}
     {{ if not $entries }}
-        <p class="muted">None</p>
+        <p class="text-muted fst-italic">None</p>
     {{ else }}
-        <ul class="account-list">
+        <ul class="list-unstyled mb-0">
             {{ range $entries }}
                 {{ template "accountCard" . }}
             {{ end }}
@@ -158,21 +282,21 @@
 
 {{ define "accountCard" }}
     {{ $entry := . }}
-    <li class="account-card">
-        <div class="account-card-main">
-            <a class="account-card-link" target="_blank" rel="noopener" href="{{ $entry.Presentation.ProfileURL }}">
-                <strong class="account-display">{{ $entry.Presentation.Display }}</strong>
+    <li class="mb-3 pb-3 border-bottom">
+        <div class="d-flex flex-column">
+            <a class="text-decoration-none" target="_blank" rel="noopener" href="{{ $entry.Presentation.ProfileURL }}">
+                <strong class="d-block">{{ $entry.Presentation.Display }}</strong>
             </a>
             {{ with $handle := $entry.Presentation.Handle }}
-                <span class="account-handle">{{ $handle }}</span>
+                <span class="text-muted small">{{ $handle }}</span>
+            {{ end }}
+            {{ if or $entry.Muted $entry.Blocked }}
+                <div class="mt-2">
+                    {{ if $entry.Muted }}<span class="badge text-bg-warning me-2">Muted</span>{{ end }}
+                    {{ if $entry.Blocked }}<span class="badge text-bg-danger">Blocked</span>{{ end }}
+                </div>
             {{ end }}
         </div>
-        {{ if or $entry.Muted $entry.Blocked }}
-        <div class="account-meta">
-            {{ if $entry.Muted }}<span class="badge badge-muted">Muted</span>{{ end }}
-            {{ if $entry.Blocked }}<span class="badge badge-block">Blocked</span>{{ end }}
-        </div>
-        {{ end }}
     </li>
 {{ end }}
 

--- a/internal/matrix/web/templates/index.tmpl
+++ b/internal/matrix/web/templates/index.tmpl
@@ -40,7 +40,7 @@
                                 <li class="list-group-item">
                                     <div class="d-flex flex-column">
                                         <span class="badge bg-info text-dark align-self-start mb-2">{{ .SlotLabel }}</span>
-                                        <span class="fw-semibold">{{ .Owner }}</span>
+                                        <span class="fw-semibold">{{ .OwnerLabel }}</span>
                                         <span class="text-muted small">{{ .FileName }}</span>
                                     </div>
                                 </li>

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1,7 +1,14 @@
 package server
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"mime/multipart"
 	"net/http"
+	"os"
+	"strings"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -10,16 +17,39 @@ import (
 )
 
 const (
-	comparisonRoutePath               = "/"
-	healthRoutePath                   = "/healthz"
-	htmlContentType                   = "text/html; charset=utf-8"
-	errorMessageComparisonUnavailable = "comparison data unavailable"
-	errorMessageRenderFailure         = "comparison page rendering failed"
-	healthStatusKey                   = "status"
-	healthStatusOK                    = "ok"
-	logMessageRenderFailure           = "comparison render failure"
-	logMessageMissingComparisonData   = "comparison data not loaded"
-	ginModeRelease                    = "release"
+	comparisonRoutePath             = "/"
+	healthRoutePath                 = "/healthz"
+	uploadsRoutePath                = "/api/uploads"
+	staticRoutePath                 = "/static"
+	htmlContentType                 = "text/html; charset=utf-8"
+	jsonContentType                 = "application/json; charset=utf-8"
+	healthStatusKey                 = "status"
+	healthStatusOK                  = "ok"
+	uploadFormFieldName             = "archives"
+	tempFilePattern                 = "fsync-upload-*.zip"
+	slotLabelPrimary                = "Archive A"
+	slotLabelSecondary              = "Archive B"
+	ownerHandlePrefix               = "@"
+	unknownOwnerLabel               = "Unknown"
+	errMessageNoFilesUploaded       = "no files were uploaded"
+	errMessageInvalidArchive        = "uploaded file must be a Twitter archive zip"
+	errMessageStoreUpdate           = "unable to store uploaded archive"
+	errMessageTooManyArchives       = "two archives already uploaded; reset before adding more"
+	errMessageRenderFailure         = "comparison page rendering failed"
+	errMessageUploadPersistFailure  = "unable to persist uploaded file"
+	logMessageRenderFailure         = "comparison render failure"
+	logMessageStoreFailure          = "upload store failure"
+	logMessageArchiveParseFailure   = "archive parse failure"
+	logMessageHandleResolution      = "resolving handles"
+	logMessageHandleResolutionError = "handle resolution failure"
+	logFieldArchiveName             = "archive"
+	logFieldAccountID               = "account_id"
+	ginModeRelease                  = "release"
+)
+
+var (
+	errNoFilesUploaded = errors.New(errMessageNoFilesUploaded)
+	errTooManyArchives = errors.New(errMessageTooManyArchives)
 )
 
 // ComparisonData contains the account sets and owner metadata used to build the comparison.
@@ -33,7 +63,7 @@ type ComparisonData struct {
 // ComparisonService encapsulates the logic required to build and render comparison pages.
 type ComparisonService interface {
 	BuildComparison(accountSetsA matrix.AccountSets, accountSetsB matrix.AccountSets, ownerA matrix.OwnerIdentity, ownerB matrix.OwnerIdentity) matrix.ComparisonResult
-	RenderComparisonPage(comparison matrix.ComparisonResult) (string, error)
+	RenderComparisonPage(pageData matrix.ComparisonPageData) (string, error)
 }
 
 // MatrixComparisonService implements ComparisonService by delegating to the matrix package.
@@ -45,18 +75,41 @@ func (MatrixComparisonService) BuildComparison(accountSetsA matrix.AccountSets, 
 }
 
 // RenderComparisonPage uses matrix.RenderComparisonPage to produce the HTML output.
-func (MatrixComparisonService) RenderComparisonPage(comparison matrix.ComparisonResult) (string, error) {
-	return matrix.RenderComparisonPage(comparison)
+func (MatrixComparisonService) RenderComparisonPage(pageData matrix.ComparisonPageData) (string, error) {
+	return matrix.RenderComparisonPage(pageData)
 }
 
 // RouterConfig configures the HTTP routing for comparison requests.
 type RouterConfig struct {
-	ComparisonData *ComparisonData
 	Service        ComparisonService
+	Store          ComparisonStore
 	Logger         *zap.Logger
+	ResolveHandles bool
+	HandleResolver matrix.AccountHandleResolver
 }
 
-// NewRouter constructs a Gin engine configured with the comparison and health handlers.
+// ComparisonStore persists uploaded archives and exposes comparison snapshots.
+type ComparisonStore interface {
+	Snapshot() ComparisonSnapshot
+	Upsert(upload ArchiveUpload) (ComparisonSnapshot, error)
+	Clear() ComparisonSnapshot
+	ResolveHandles(ctx context.Context, resolver matrix.AccountHandleResolver) map[string]error
+}
+
+// ComparisonSnapshot represents the current upload state and optional comparison data.
+type ComparisonSnapshot struct {
+	Uploads        []matrix.UploadSummary
+	ComparisonData *ComparisonData
+}
+
+// ArchiveUpload captures the data parsed from an uploaded archive.
+type ArchiveUpload struct {
+	FileName    string
+	AccountSets matrix.AccountSets
+	Owner       matrix.OwnerIdentity
+}
+
+// NewRouter constructs a Gin engine configured with comparison, upload, static, and health handlers.
 func NewRouter(configuration RouterConfig) (*gin.Engine, error) {
 	service := configuration.Service
 	if service == nil {
@@ -66,51 +119,353 @@ func NewRouter(configuration RouterConfig) (*gin.Engine, error) {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
+	store := configuration.Store
+	if store == nil {
+		store = newMemoryComparisonStore()
+	}
 
 	gin.SetMode(ginModeRelease)
 	engine := gin.New()
 	engine.Use(gin.Recovery())
 
-	handler := comparisonHandler{
-		data:    configuration.ComparisonData,
-		service: service,
-		logger:  logger,
+	staticFiles, err := matrix.StaticAssets()
+	if err != nil {
+		return nil, fmt.Errorf("load static assets: %w", err)
+	}
+	engine.StaticFS(staticRoutePath, http.FS(staticFiles))
+
+	handler := applicationHandler{
+		store:          store,
+		service:        service,
+		logger:         logger,
+		resolveHandles: configuration.ResolveHandles,
+		handleResolver: configuration.HandleResolver,
 	}
 
 	engine.GET(comparisonRoutePath, handler.serveComparison)
 	engine.GET(healthRoutePath, handler.healthStatus)
+	engine.POST(uploadsRoutePath, handler.uploadArchives)
+	engine.DELETE(uploadsRoutePath, handler.resetArchives)
 
 	return engine, nil
 }
 
-type comparisonHandler struct {
-	data    *ComparisonData
-	service ComparisonService
-	logger  *zap.Logger
+type applicationHandler struct {
+	store          ComparisonStore
+	service        ComparisonService
+	logger         *zap.Logger
+	resolveHandles bool
+	handleResolver matrix.AccountHandleResolver
 }
 
-func (handler comparisonHandler) serveComparison(ginContext *gin.Context) {
-	if handler.data == nil {
-		handler.logger.Error(logMessageMissingComparisonData)
-		ginContext.String(http.StatusInternalServerError, errorMessageComparisonUnavailable)
-		return
+func (handler applicationHandler) serveComparison(ginContext *gin.Context) {
+	snapshot := handler.store.Snapshot()
+	var comparisonResult *matrix.ComparisonResult
+	if snapshot.ComparisonData != nil {
+		result := handler.service.BuildComparison(
+			snapshot.ComparisonData.AccountSetsA,
+			snapshot.ComparisonData.AccountSetsB,
+			snapshot.ComparisonData.OwnerA,
+			snapshot.ComparisonData.OwnerB,
+		)
+		comparisonResult = &result
 	}
 
-	comparison := handler.service.BuildComparison(
-		handler.data.AccountSetsA,
-		handler.data.AccountSetsB,
-		handler.data.OwnerA,
-		handler.data.OwnerB,
-	)
-	pageHTML, err := handler.service.RenderComparisonPage(comparison)
+	pageHTML, err := handler.service.RenderComparisonPage(matrix.ComparisonPageData{
+		Comparison: comparisonResult,
+		Uploads:    snapshot.Uploads,
+	})
 	if err != nil {
 		handler.logger.Error(logMessageRenderFailure, zap.Error(err))
-		ginContext.String(http.StatusInternalServerError, errorMessageRenderFailure)
+		ginContext.Data(http.StatusInternalServerError, htmlContentType, []byte(errMessageRenderFailure))
 		return
 	}
 	ginContext.Data(http.StatusOK, htmlContentType, []byte(pageHTML))
 }
 
-func (handler comparisonHandler) healthStatus(ginContext *gin.Context) {
+func (handler applicationHandler) healthStatus(ginContext *gin.Context) {
 	ginContext.JSON(http.StatusOK, map[string]string{healthStatusKey: healthStatusOK})
+}
+
+func (handler applicationHandler) uploadArchives(ginContext *gin.Context) {
+	multipartForm, err := ginContext.MultipartForm()
+	if err != nil {
+		handler.writeJSONError(ginContext, http.StatusBadRequest, errMessageNoFilesUploaded)
+		return
+	}
+	files := multipartForm.File[uploadFormFieldName]
+	if len(files) == 0 {
+		handler.writeJSONError(ginContext, http.StatusBadRequest, errMessageNoFilesUploaded)
+		return
+	}
+
+	var snapshot ComparisonSnapshot
+	for _, fileHeader := range files {
+		tempPath, cleanup, saveErr := handler.saveUploadedFile(ginContext, fileHeader)
+		if saveErr != nil {
+			handler.logger.Error(logMessageArchiveParseFailure, zap.Error(saveErr), zap.String(logFieldArchiveName, fileHeader.Filename))
+			handler.writeJSONError(ginContext, http.StatusInternalServerError, errMessageUploadPersistFailure)
+			if cleanup != nil {
+				cleanup()
+			}
+			return
+		}
+
+		accountSets, owner, parseErr := matrix.ReadTwitterZip(tempPath)
+		if cleanup != nil {
+			cleanup()
+		}
+		if parseErr != nil {
+			handler.logger.Error(logMessageArchiveParseFailure, zap.Error(parseErr), zap.String(logFieldArchiveName, fileHeader.Filename))
+			handler.writeJSONError(ginContext, http.StatusBadRequest, fmt.Sprintf("%s: %v", errMessageInvalidArchive, parseErr))
+			return
+		}
+
+		upload := ArchiveUpload{FileName: fileHeader.Filename, AccountSets: accountSets, Owner: owner}
+		snapshot, err = handler.store.Upsert(upload)
+		if err != nil {
+			handler.logger.Error(logMessageStoreFailure, zap.Error(err), zap.String(logFieldArchiveName, fileHeader.Filename))
+			if errors.Is(err, errTooManyArchives) {
+				handler.writeJSONError(ginContext, http.StatusBadRequest, err.Error())
+			} else {
+				handler.writeJSONError(ginContext, http.StatusInternalServerError, errMessageStoreUpdate)
+			}
+			return
+		}
+	}
+
+	if handler.resolveHandles && handler.handleResolver != nil && snapshot.ComparisonData != nil {
+		handler.logger.Info(logMessageHandleResolution)
+		go handler.resolveHandlesAsync()
+	}
+
+	ginContext.Header("Content-Type", jsonContentType)
+	ginContext.JSON(http.StatusOK, uploadResponse{
+		Uploads:         snapshot.Uploads,
+		ComparisonReady: snapshot.ComparisonData != nil,
+	})
+}
+
+func (handler applicationHandler) resetArchives(ginContext *gin.Context) {
+	handler.store.Clear()
+	ginContext.Status(http.StatusNoContent)
+}
+
+func (handler applicationHandler) resolveHandlesAsync() {
+	errorsByAccountID := handler.store.ResolveHandles(context.Background(), handler.handleResolver)
+	for accountID, resolutionErr := range errorsByAccountID {
+		handler.logger.Warn(logMessageHandleResolutionError, zap.String(logFieldAccountID, accountID), zap.Error(resolutionErr))
+	}
+}
+
+func (handler applicationHandler) saveUploadedFile(ginContext *gin.Context, fileHeader *multipart.FileHeader) (string, func(), error) {
+	tempFile, err := os.CreateTemp("", tempFilePattern)
+	if err != nil {
+		return "", nil, fmt.Errorf("create temp file: %w", err)
+	}
+	tempPath := tempFile.Name()
+	if closeErr := tempFile.Close(); closeErr != nil {
+		_ = os.Remove(tempPath)
+		return "", nil, fmt.Errorf("close temp file: %w", closeErr)
+	}
+	if err := ginContext.SaveUploadedFile(fileHeader, tempPath); err != nil {
+		_ = os.Remove(tempPath)
+		return "", nil, fmt.Errorf("save upload: %w", err)
+	}
+	cleanup := func() { _ = os.Remove(tempPath) }
+	return tempPath, cleanup, nil
+}
+
+func (handler applicationHandler) writeJSONError(ginContext *gin.Context, statusCode int, message string) {
+	ginContext.Header("Content-Type", jsonContentType)
+	ginContext.JSON(statusCode, errorResponse{Error: message})
+}
+
+type uploadResponse struct {
+	Uploads         []matrix.UploadSummary `json:"uploads"`
+	ComparisonReady bool                   `json:"comparisonReady"`
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+type memoryComparisonStore struct {
+	mutex     sync.RWMutex
+	primary   *archiveRecord
+	secondary *archiveRecord
+}
+
+type archiveRecord struct {
+	slotLabel   string
+	fileName    string
+	owner       matrix.OwnerIdentity
+	accountSets matrix.AccountSets
+}
+
+func newMemoryComparisonStore() *memoryComparisonStore {
+	return &memoryComparisonStore{}
+}
+
+func (store *memoryComparisonStore) Snapshot() ComparisonSnapshot {
+	store.mutex.RLock()
+	defer store.mutex.RUnlock()
+	return store.snapshotLocked()
+}
+
+func (store *memoryComparisonStore) Upsert(upload ArchiveUpload) (ComparisonSnapshot, error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+
+	record := archiveRecord{
+		fileName:    upload.FileName,
+		owner:       upload.Owner,
+		accountSets: copyAccountSets(upload.AccountSets),
+	}
+
+	if store.primary == nil {
+		record.slotLabel = slotLabelPrimary
+		store.primary = &record
+		return store.snapshotLocked(), nil
+	}
+	if sameOwner(store.primary.owner, record.owner) || sameFileForUnknownOwner(*store.primary, record) {
+		record.slotLabel = store.primary.slotLabel
+		store.primary = &record
+		return store.snapshotLocked(), nil
+	}
+	if store.secondary == nil {
+		record.slotLabel = slotLabelSecondary
+		store.secondary = &record
+		return store.snapshotLocked(), nil
+	}
+	if sameOwner(store.secondary.owner, record.owner) || sameFileForUnknownOwner(*store.secondary, record) {
+		record.slotLabel = store.secondary.slotLabel
+		store.secondary = &record
+		return store.snapshotLocked(), nil
+	}
+	return ComparisonSnapshot{}, errTooManyArchives
+}
+
+func (store *memoryComparisonStore) Clear() ComparisonSnapshot {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	store.primary = nil
+	store.secondary = nil
+	return store.snapshotLocked()
+}
+
+func (store *memoryComparisonStore) ResolveHandles(ctx context.Context, resolver matrix.AccountHandleResolver) map[string]error {
+	store.mutex.RLock()
+	if store.primary == nil || store.secondary == nil {
+		store.mutex.RUnlock()
+		return nil
+	}
+	primary := *store.primary
+	secondary := *store.secondary
+	store.mutex.RUnlock()
+
+	accountSetsPrimary := copyAccountSets(primary.accountSets)
+	accountSetsSecondary := copyAccountSets(secondary.accountSets)
+	errorsByAccountID := matrix.MaybeResolveHandles(ctx, resolver, true, &accountSetsPrimary, &accountSetsSecondary)
+
+	store.mutex.Lock()
+	if store.primary != nil && (sameOwner(store.primary.owner, primary.owner) || sameFileForUnknownOwner(*store.primary, primary)) {
+		store.primary.accountSets = accountSetsPrimary
+	}
+	if store.secondary != nil && (sameOwner(store.secondary.owner, secondary.owner) || sameFileForUnknownOwner(*store.secondary, secondary)) {
+		store.secondary.accountSets = accountSetsSecondary
+	}
+	store.mutex.Unlock()
+	return errorsByAccountID
+}
+
+func (store *memoryComparisonStore) snapshotLocked() ComparisonSnapshot {
+	uploads := make([]matrix.UploadSummary, 0, 2)
+	if store.primary != nil {
+		uploads = append(uploads, matrix.UploadSummary{SlotLabel: store.primary.slotLabel, OwnerLabel: ownerSummary(store.primary.owner), FileName: store.primary.fileName})
+	}
+	if store.secondary != nil {
+		uploads = append(uploads, matrix.UploadSummary{SlotLabel: store.secondary.slotLabel, OwnerLabel: ownerSummary(store.secondary.owner), FileName: store.secondary.fileName})
+	}
+	var comparison *ComparisonData
+	if store.primary != nil && store.secondary != nil {
+		comparison = &ComparisonData{
+			AccountSetsA: copyAccountSets(store.primary.accountSets),
+			AccountSetsB: copyAccountSets(store.secondary.accountSets),
+			OwnerA:       store.primary.owner,
+			OwnerB:       store.secondary.owner,
+		}
+	}
+	return ComparisonSnapshot{Uploads: uploads, ComparisonData: comparison}
+}
+
+func sameOwner(first matrix.OwnerIdentity, second matrix.OwnerIdentity) bool {
+	if strings.TrimSpace(first.AccountID) != "" && strings.TrimSpace(second.AccountID) != "" {
+		return strings.EqualFold(first.AccountID, second.AccountID)
+	}
+	if strings.TrimSpace(first.UserName) != "" && strings.TrimSpace(second.UserName) != "" {
+		return strings.EqualFold(first.UserName, second.UserName)
+	}
+	return false
+}
+
+func sameFileForUnknownOwner(existing archiveRecord, incoming archiveRecord) bool {
+	if strings.TrimSpace(existing.owner.AccountID) != "" || strings.TrimSpace(incoming.owner.AccountID) != "" {
+		return false
+	}
+	if strings.TrimSpace(existing.owner.UserName) != "" || strings.TrimSpace(incoming.owner.UserName) != "" {
+		return false
+	}
+	if strings.TrimSpace(existing.fileName) == "" || strings.TrimSpace(incoming.fileName) == "" {
+		return false
+	}
+	return strings.EqualFold(existing.fileName, incoming.fileName)
+}
+
+func ownerSummary(owner matrix.OwnerIdentity) string {
+	display := strings.TrimSpace(owner.DisplayName)
+	handle := strings.TrimSpace(owner.UserName)
+	switch {
+	case display != "" && handle != "":
+		return fmt.Sprintf("%s (%s%s)", display, ownerHandlePrefix, handle)
+	case display != "":
+		return display
+	case handle != "":
+		return ownerHandlePrefix + handle
+	case strings.TrimSpace(owner.AccountID) != "":
+		return owner.AccountID
+	default:
+		return unknownOwnerLabel
+	}
+}
+
+func copyAccountSets(source matrix.AccountSets) matrix.AccountSets {
+	return matrix.AccountSets{
+		Followers: copyAccountRecordMap(source.Followers),
+		Following: copyAccountRecordMap(source.Following),
+		Muted:     copyBoolMap(source.Muted),
+		Blocked:   copyBoolMap(source.Blocked),
+	}
+}
+
+func copyAccountRecordMap(source map[string]matrix.AccountRecord) map[string]matrix.AccountRecord {
+	if len(source) == 0 {
+		return map[string]matrix.AccountRecord{}
+	}
+	cloned := make(map[string]matrix.AccountRecord, len(source))
+	for key, value := range source {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func copyBoolMap(source map[string]bool) map[string]bool {
+	if len(source) == 0 {
+		return map[string]bool{}
+	}
+	cloned := make(map[string]bool, len(source))
+	for key, value := range source {
+		cloned[key] = value
+	}
+	return cloned
 }

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -143,6 +143,10 @@ func TestServeComparisonResponses(t *testing.T) {
 }
 
 func TestUploadArchivesFlow(t *testing.T) {
+	const (
+		expectedOwnerSummaryArchiveA = "Owner A (@owner_a)"
+		expectedOwnerSummaryArchiveB = "Owner B (@owner_b)"
+	)
 	router, err := server.NewRouter(server.RouterConfig{})
 	if err != nil {
 		t.Fatalf("NewRouter returned error: %v", err)
@@ -173,6 +177,12 @@ func TestUploadArchivesFlow(t *testing.T) {
 	if firstResponse.ComparisonReady {
 		t.Fatalf("expected comparison to be unavailable after first upload")
 	}
+	if len(firstResponse.Uploads) != 1 {
+		t.Fatalf("expected one upload in response, got %d", len(firstResponse.Uploads))
+	}
+	if firstResponse.Uploads[0].OwnerLabel != expectedOwnerSummaryArchiveA {
+		t.Fatalf("expected owner label %q, got %q", expectedOwnerSummaryArchiveA, firstResponse.Uploads[0].OwnerLabel)
+	}
 
 	// Second upload
 	recorder = httptest.NewRecorder()
@@ -187,6 +197,15 @@ func TestUploadArchivesFlow(t *testing.T) {
 	}
 	if !secondResponse.ComparisonReady {
 		t.Fatalf("expected comparison to be ready after second upload")
+	}
+	if len(secondResponse.Uploads) != 2 {
+		t.Fatalf("expected two uploads in response, got %d", len(secondResponse.Uploads))
+	}
+	if secondResponse.Uploads[0].OwnerLabel != expectedOwnerSummaryArchiveA {
+		t.Fatalf("expected first owner label %q, got %q", expectedOwnerSummaryArchiveA, secondResponse.Uploads[0].OwnerLabel)
+	}
+	if secondResponse.Uploads[1].OwnerLabel != expectedOwnerSummaryArchiveB {
+		t.Fatalf("expected second owner label %q, got %q", expectedOwnerSummaryArchiveB, secondResponse.Uploads[1].OwnerLabel)
 	}
 
 	// Ensure GET renders HTML containing the owner name

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -1,9 +1,17 @@
 package server_test
 
 import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -14,96 +22,101 @@ import (
 type comparisonServiceStub struct {
 	renderedHTML string
 	renderError  error
+	lastPageData matrix.ComparisonPageData
 }
 
-func (stub comparisonServiceStub) BuildComparison(accountSetsA matrix.AccountSets, accountSetsB matrix.AccountSets, ownerA matrix.OwnerIdentity, ownerB matrix.OwnerIdentity) matrix.ComparisonResult {
-	return matrix.ComparisonResult{
-		AccountSetsA: accountSetsA,
-		AccountSetsB: accountSetsB,
-		OwnerA:       ownerA,
-		OwnerB:       ownerB,
-	}
+func (stub *comparisonServiceStub) BuildComparison(accountSetsA matrix.AccountSets, accountSetsB matrix.AccountSets, ownerA matrix.OwnerIdentity, ownerB matrix.OwnerIdentity) matrix.ComparisonResult {
+	return matrix.ComparisonResult{AccountSetsA: accountSetsA, AccountSetsB: accountSetsB, OwnerA: ownerA, OwnerB: ownerB}
 }
 
-func (stub comparisonServiceStub) RenderComparisonPage(matrix.ComparisonResult) (string, error) {
+func (stub *comparisonServiceStub) RenderComparisonPage(pageData matrix.ComparisonPageData) (string, error) {
+	stub.lastPageData = pageData
 	return stub.renderedHTML, stub.renderError
+}
+
+type comparisonStoreStub struct {
+	snapshot server.ComparisonSnapshot
+}
+
+func (stub comparisonStoreStub) Snapshot() server.ComparisonSnapshot {
+	return stub.snapshot
+}
+
+func (comparisonStoreStub) Upsert(server.ArchiveUpload) (server.ComparisonSnapshot, error) {
+	return server.ComparisonSnapshot{}, nil
+}
+
+func (comparisonStoreStub) Clear() server.ComparisonSnapshot {
+	return server.ComparisonSnapshot{}
+}
+
+func (comparisonStoreStub) ResolveHandles(context.Context, matrix.AccountHandleResolver) map[string]error {
+	return nil
 }
 
 func TestServeComparisonResponses(t *testing.T) {
 	const (
-		accountIDAlpha                     = "1001"
-		ownerAccountIDAlpha                = "2001"
-		ownerAccountIDBeta                 = "2002"
-		ownerHandleAlpha                   = "owner_alpha"
-		ownerHandleBeta                    = "owner_beta"
-		ownerDisplayAlpha                  = "Owner Alpha"
-		ownerDisplayBeta                   = "Owner Beta"
-		placeholderHTML                    = "<html><body>ok</body></html>"
-		expectedMissingDataBodySubstring   = "comparison data unavailable"
-		expectedRenderFailureBodySubstring = "comparison page rendering failed"
-		renderFailureErrorMessage          = "render failure"
+		placeholderHTML           = "<html><body>ok</body></html>"
+		renderFailureErrorMessage = "render failure"
+		expectedRenderError       = "comparison page rendering failed"
 	)
 
-	ownerIdentityAlpha := matrix.OwnerIdentity{AccountID: ownerAccountIDAlpha, UserName: ownerHandleAlpha, DisplayName: ownerDisplayAlpha}
-	ownerIdentityBeta := matrix.OwnerIdentity{AccountID: ownerAccountIDBeta, UserName: ownerHandleBeta, DisplayName: ownerDisplayBeta}
-	populatedComparisonData := &server.ComparisonData{
-		AccountSetsA: matrix.AccountSets{
-			Followers: map[string]matrix.AccountRecord{
-				accountIDAlpha: {AccountID: accountIDAlpha, UserName: ownerHandleAlpha, DisplayName: ownerDisplayAlpha},
-			},
-			Following: map[string]matrix.AccountRecord{
-				accountIDAlpha: {AccountID: accountIDAlpha, UserName: ownerHandleAlpha, DisplayName: ownerDisplayAlpha},
-			},
-			Muted:   map[string]bool{},
-			Blocked: map[string]bool{},
-		},
-		AccountSetsB: matrix.AccountSets{
-			Followers: map[string]matrix.AccountRecord{},
-			Following: map[string]matrix.AccountRecord{},
-			Muted:     map[string]bool{},
-			Blocked:   map[string]bool{},
-		},
-		OwnerA: ownerIdentityAlpha,
-		OwnerB: ownerIdentityBeta,
+	comparisonData := &server.ComparisonData{
+		AccountSetsA: matrix.AccountSets{Followers: map[string]matrix.AccountRecord{"1": {AccountID: "1"}}},
+		AccountSetsB: matrix.AccountSets{Followers: map[string]matrix.AccountRecord{"2": {AccountID: "2"}}},
+		OwnerA:       matrix.OwnerIdentity{AccountID: "1", UserName: "owner_a", DisplayName: "Owner A"},
+		OwnerB:       matrix.OwnerIdentity{AccountID: "2", UserName: "owner_b", DisplayName: "Owner B"},
 	}
 
 	testCases := []struct {
 		name               string
-		data               *server.ComparisonData
-		service            server.ComparisonService
+		snapshot           server.ComparisonSnapshot
+		service            *comparisonServiceStub
 		expectedStatusCode int
 		expectedBody       string
+		expectComparison   bool
 	}{
 		{
-			name:               "success returns html",
-			data:               populatedComparisonData,
-			service:            comparisonServiceStub{renderedHTML: placeholderHTML},
+			name: "renders comparison when data available",
+			snapshot: server.ComparisonSnapshot{
+				ComparisonData: comparisonData,
+				Uploads:        []matrix.UploadSummary{{SlotLabel: "Archive A", OwnerLabel: "Owner A", FileName: "a.zip"}},
+			},
+			service:            &comparisonServiceStub{renderedHTML: placeholderHTML},
 			expectedStatusCode: http.StatusOK,
 			expectedBody:       placeholderHTML,
+			expectComparison:   true,
 		},
 		{
-			name:               "missing data returns server error",
-			data:               nil,
-			service:            comparisonServiceStub{renderedHTML: placeholderHTML},
-			expectedStatusCode: http.StatusInternalServerError,
-			expectedBody:       expectedMissingDataBodySubstring,
+			name: "renders empty state when data missing",
+			snapshot: server.ComparisonSnapshot{
+				Uploads: []matrix.UploadSummary{{SlotLabel: "Archive A", OwnerLabel: "Owner A", FileName: "a.zip"}},
+			},
+			service:            &comparisonServiceStub{renderedHTML: placeholderHTML},
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       placeholderHTML,
+			expectComparison:   false,
 		},
 		{
-			name: "render failure returns error",
-			data: populatedComparisonData,
-			service: comparisonServiceStub{
+			name:     "render failure returns error",
+			snapshot: server.ComparisonSnapshot{ComparisonData: comparisonData},
+			service: &comparisonServiceStub{
 				renderedHTML: "",
 				renderError:  errors.New(renderFailureErrorMessage),
 			},
 			expectedStatusCode: http.StatusInternalServerError,
-			expectedBody:       expectedRenderFailureBodySubstring,
+			expectedBody:       expectedRenderError,
+			expectComparison:   true,
 		},
 	}
 
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
-			router, err := server.NewRouter(server.RouterConfig{ComparisonData: testCase.data, Service: testCase.service})
+			router, err := server.NewRouter(server.RouterConfig{
+				Service: testCase.service,
+				Store:   comparisonStoreStub{snapshot: testCase.snapshot},
+			})
 			if err != nil {
 				t.Fatalf("NewRouter returned error: %v", err)
 			}
@@ -117,64 +130,175 @@ func TestServeComparisonResponses(t *testing.T) {
 			if !strings.Contains(body, testCase.expectedBody) {
 				t.Fatalf("expected body to contain %q, got %q", testCase.expectedBody, body)
 			}
+			if testCase.service != nil {
+				if testCase.expectComparison && testCase.service.lastPageData.Comparison == nil {
+					t.Fatalf("expected comparison data to be passed to renderer")
+				}
+				if !testCase.expectComparison && testCase.service.lastPageData.Comparison != nil {
+					t.Fatalf("expected comparison to be nil")
+				}
+			}
 		})
 	}
 }
 
-func TestRouterIntegrationRendersPage(t *testing.T) {
-	const (
-		ownerAccountIDAlpha = "3001"
-		ownerAccountIDBeta  = "3002"
-		ownerHandleAlpha    = "owner_a"
-		ownerHandleBeta     = "owner_b"
-		ownerDisplayAlpha   = "Owner A"
-		ownerDisplayBeta    = "Owner B"
-		friendAccountID     = "4001"
-		friendHandle        = "friend_account"
-		friendDisplay       = "Friend Account"
-		expectedTitleText   = "<title>"
-		expectedSectionText = "Overview"
-		expectedFriendText  = "Friend Account"
-	)
-
-	comparisonData := &server.ComparisonData{
-		AccountSetsA: matrix.AccountSets{
-			Followers: map[string]matrix.AccountRecord{
-				friendAccountID: {AccountID: friendAccountID, UserName: friendHandle, DisplayName: friendDisplay},
-			},
-			Following: map[string]matrix.AccountRecord{
-				friendAccountID: {AccountID: friendAccountID, UserName: friendHandle, DisplayName: friendDisplay},
-			},
-			Muted: map[string]bool{
-				friendAccountID: true,
-			},
-			Blocked: map[string]bool{},
-		},
-		AccountSetsB: matrix.AccountSets{
-			Followers: map[string]matrix.AccountRecord{},
-			Following: map[string]matrix.AccountRecord{},
-			Muted:     map[string]bool{},
-			Blocked:   map[string]bool{},
-		},
-		OwnerA: matrix.OwnerIdentity{AccountID: ownerAccountIDAlpha, UserName: ownerHandleAlpha, DisplayName: ownerDisplayAlpha},
-		OwnerB: matrix.OwnerIdentity{AccountID: ownerAccountIDBeta, UserName: ownerHandleBeta, DisplayName: ownerDisplayBeta},
-	}
-
-	router, err := server.NewRouter(server.RouterConfig{ComparisonData: comparisonData, Service: server.MatrixComparisonService{}})
+func TestUploadArchivesFlow(t *testing.T) {
+	router, err := server.NewRouter(server.RouterConfig{})
 	if err != nil {
 		t.Fatalf("NewRouter returned error: %v", err)
 	}
 
+	archiveA := createArchive(t, map[string]string{
+		"manifest.js":  `{"userInfo":{"accountId":"1","userName":"owner_a","displayName":"Owner A"}}`,
+		"following.js": `[{"following":{"accountId":"10","userName":"friend_a","displayName":"Friend A"}}]`,
+		"follower.js":  `[{"follower":{"accountId":"11","userName":"follower_a","displayName":"Follower A"}}]`,
+	})
+	archiveB := createArchive(t, map[string]string{
+		"manifest.js":  `{"userInfo":{"accountId":"2","userName":"owner_b","displayName":"Owner B"}}`,
+		"following.js": `[{"following":{"accountId":"20","userName":"friend_b","displayName":"Friend B"}}]`,
+		"follower.js":  `[{"follower":{"accountId":"21","userName":"follower_b","displayName":"Follower B"}}]`,
+	})
+
+	// First upload
 	recorder := httptest.NewRecorder()
-	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request := newUploadRequest(t, archiveA)
 	router.ServeHTTP(recorder, request)
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
 	}
-	body := recorder.Body.String()
-	for _, expectedSnippet := range []string{expectedTitleText, expectedSectionText, expectedFriendText} {
-		if !strings.Contains(body, expectedSnippet) {
-			t.Fatalf("expected body to contain %q", expectedSnippet)
+	var firstResponse uploadResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &firstResponse); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if firstResponse.ComparisonReady {
+		t.Fatalf("expected comparison to be unavailable after first upload")
+	}
+
+	// Second upload
+	recorder = httptest.NewRecorder()
+	request = newUploadRequest(t, archiveB)
+	router.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
+	}
+	var secondResponse uploadResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &secondResponse); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !secondResponse.ComparisonReady {
+		t.Fatalf("expected comparison to be ready after second upload")
+	}
+
+	// Ensure GET renders HTML containing the owner name
+	recorder = httptest.NewRecorder()
+	request = httptest.NewRequest(http.MethodGet, "/", nil)
+	router.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
+	}
+	if !strings.Contains(recorder.Body.String(), "Owner A (@owner_a) — Relationship Matrix") {
+		t.Fatalf("expected rendered page to include owner name")
+	}
+}
+
+func TestUploadArchivesRejectsInvalidZip(t *testing.T) {
+	router, err := server.NewRouter(server.RouterConfig{})
+	if err != nil {
+		t.Fatalf("NewRouter returned error: %v", err)
+	}
+
+	invalidArchive := createArchive(t, map[string]string{
+		"manifest.js": `{"userInfo":{"accountId":"3"}}`,
+	})
+
+	recorder := httptest.NewRecorder()
+	request := newUploadRequest(t, invalidArchive)
+	router.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, recorder.Code)
+	}
+	var response uploadErrorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !strings.Contains(response.Error, "uploaded file must be a Twitter archive zip") {
+		t.Fatalf("expected error message to mention invalid archive, got %q", response.Error)
+	}
+}
+
+func TestStaticAssetServed(t *testing.T) {
+	router, err := server.NewRouter(server.RouterConfig{})
+	if err != nil {
+		t.Fatalf("NewRouter returned error: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/static/app.js", nil)
+	router.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
+	}
+	if !strings.Contains(recorder.Body.String(), "initializeUploadUI") {
+		t.Fatalf("expected JS bundle to include upload initializer")
+	}
+}
+
+type uploadResponse struct {
+	Uploads         []matrix.UploadSummary `json:"uploads"`
+	ComparisonReady bool                   `json:"comparisonReady"`
+}
+
+type uploadErrorResponse struct {
+	Error string `json:"error"`
+}
+
+func newUploadRequest(t *testing.T, archivePath string) *http.Request {
+	t.Helper()
+	file, err := os.Open(archivePath)
+	if err != nil {
+		t.Fatalf("open archive: %v", err)
+	}
+	defer file.Close()
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("archives", filepath.Base(archivePath))
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := io.Copy(part, file); err != nil {
+		t.Fatalf("copy archive: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/api/uploads", body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	return request
+}
+
+func createArchive(t *testing.T, files map[string]string) string {
+	t.Helper()
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "archive.zip")
+
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	defer file.Close()
+
+	writer := zip.NewWriter(file)
+	for name, content := range files {
+		entry, err := writer.Create(name)
+		if err != nil {
+			t.Fatalf("create entry: %v", err)
+		}
+		if _, err := entry.Write([]byte(content)); err != nil {
+			t.Fatalf("write entry: %v", err)
 		}
 	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close archive writer: %v", err)
+	}
+	return archivePath
 }


### PR DESCRIPTION
## Summary
- allow the server binary to start without preloaded archives and wire optional handle resolution when enabled
- expand the HTTP router with in-memory upload storage, ZIP ingestion endpoints, and static asset serving
- refresh the matrix page template, CSS, and client script with a Bootstrap dropzone layout and dynamic comparison controls
- update matrix and server tests to cover the new rendering model and upload workflow

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cb1af9852483278f9539f7ca6f3e04