### PR TITLE
Add upload summary owner labels to matrix UI

### DIFF
--- a/internal/matrix/models.go
+++ b/internal/matrix/models.go
@@ -15,9 +15,23 @@ type AccountSets struct {
 
 // OwnerIdentity describes the owner of a Twitter export archive.
 type OwnerIdentity struct {
-	AccountID   string
-	UserName    string
-	DisplayName string
+	AccountID   string `json:"accountId"`
+	UserName    string `json:"userName"`
+	DisplayName string `json:"displayName"`
+}
+
+const (
+	// UploadSummaryOwnerKeyPrimary identifies the first archive upload in derived views.
+	UploadSummaryOwnerKeyPrimary = "A"
+	// UploadSummaryOwnerKeySecondary identifies the second archive upload in derived views.
+	UploadSummaryOwnerKeySecondary = "B"
+)
+
+// UploadSummary provides client facing metadata for each uploaded archive owner.
+type UploadSummary struct {
+	OwnerKey   string        `json:"ownerKey"`
+	OwnerLabel string        `json:"ownerLabel"`
+	Owner      OwnerIdentity `json:"owner"`
 }
 
 // ComparisonResult holds all derived data required to render a comparison view.

--- a/internal/matrix/render_test.go
+++ b/internal/matrix/render_test.go
@@ -20,6 +20,10 @@ func TestRenderComparisonPageStructure(t *testing.T) {
 		snippetTableOfContentsAnchor = "<a class=\"toc-link\" href=\"#overview\">Overview</a>"
 		snippetSectionToggleControl  = "<button type=\"button\" class=\"section-toggle\" data-section-id=\"overview-content\" aria-expanded=\"true\" aria-controls=\"overview-content\">Hide</button>"
 		snippetSectionContent        = "<div class=\"section-content\" id=\"overview-content\">"
+		snippetUploadList            = "<ul class=\"upload-summary-list\">"
+		snippetUploadOwnerA          = "<li class=\"upload-summary-item\">Owner A (@owner_a)</li>"
+		snippetUploadOwnerB          = "<li class=\"upload-summary-item\">Owner B (@owner_b)</li>"
+		snippetOwnerLabelJSON        = "\"ownerLabel\":\"Owner A (@owner_a)\""
 	)
 
 	decoratedRecord := matrix.AccountRecord{AccountID: "42", UserName: "presented", DisplayName: "Muted Blocked"}
@@ -57,6 +61,10 @@ func TestRenderComparisonPageStructure(t *testing.T) {
 				snippetTableOfContentsAnchor,
 				snippetSectionToggleControl,
 				snippetSectionContent,
+				snippetUploadList,
+				snippetUploadOwnerA,
+				snippetUploadOwnerB,
+				snippetOwnerLabelJSON,
 			},
 		},
 		{
@@ -81,6 +89,7 @@ func TestRenderComparisonPageStructure(t *testing.T) {
 				snippetTableOfContentsAnchor,
 				snippetSectionToggleControl,
 				snippetSectionContent,
+				snippetUploadList,
 			},
 		},
 	}

--- a/internal/matrix/web/static/app.js
+++ b/internal/matrix/web/static/app.js
@@ -36,6 +36,8 @@
     const VALUE_STATE_FALSE = "false";
     const TEXT_HIDE = "Hide";
     const TEXT_SHOW = "Show";
+    const OWNER_KEY_PRIMARY = "A";
+    const OWNER_KEY_SECONDARY = "B";
 
     function indexById(arr) {
         const map = new Map();
@@ -44,6 +46,9 @@
         }
         return map;
     }
+
+    const uploadSummaries = Array.isArray(data?.uploads) ? data.uploads : [];
+    const ownerLabelsByKey = createOwnerLabelLookup(uploadSummaries);
 
     // Indexed records for both owners
     const A = {
@@ -56,6 +61,9 @@
         following: indexById(data?.B?.following || []),
         meta: createMetaLookup(data?.B?.muted || [], data?.B?.blocked || []),
     };
+
+    A.ownerLabel = ownerLabelsByKey.get(OWNER_KEY_PRIMARY) || data?.ownerA || "";
+    B.ownerLabel = ownerLabelsByKey.get(OWNER_KEY_SECONDARY) || data?.ownerB || "";
 
     // ----- set helpers -----
     function toList(map) {
@@ -99,6 +107,18 @@
                 return blockedSet.has(accountID);
             },
         };
+    }
+
+    function createOwnerLabelLookup(uploadSummaries) {
+        const map = new Map();
+        for (const summary of (uploadSummaries || [])) {
+            if (!summary) continue;
+            const ownerKeyValue = typeof summary.ownerKey === "string" ? summary.ownerKey.trim() : "";
+            if (!ownerKeyValue) continue;
+            const ownerLabelValue = typeof summary.ownerLabel === "string" ? summary.ownerLabel.trim() : "";
+            map.set(ownerKeyValue, ownerLabelValue);
+        }
+        return map;
     }
 
     // ----- URL + rendering helpers -----

--- a/internal/matrix/web/templates/index.tmpl
+++ b/internal/matrix/web/templates/index.tmpl
@@ -30,6 +30,13 @@
         <button type="button" class="section-toggle" data-section-id="overview-content" aria-expanded="true" aria-controls="overview-content">Hide</button>
     </div>
     <div class="section-content" id="overview-content">
+        {{ if .UploadSummaries }}
+        <ul class="upload-summary-list">
+            {{ range .UploadSummaries }}
+                <li class="upload-summary-item">{{ .OwnerLabel }}</li>
+            {{ end }}
+        </ul>
+        {{ end }}
         <div class="grid">
             <div>
                 <h3>{{ .OwnerA }}</h3>

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -135,6 +135,7 @@ func TestRouterIntegrationRendersPage(t *testing.T) {
 		expectedTitleText   = "<title>"
 		expectedSectionText = "Overview"
 		expectedFriendText  = "Friend Account"
+		expectedOwnerLabel  = "Owner A (@owner_a)"
 	)
 
 	comparisonData := &server.ComparisonData{
@@ -172,7 +173,7 @@ func TestRouterIntegrationRendersPage(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
 	}
 	body := recorder.Body.String()
-	for _, expectedSnippet := range []string{expectedTitleText, expectedSectionText, expectedFriendText} {
+	for _, expectedSnippet := range []string{expectedTitleText, expectedSectionText, expectedFriendText, expectedOwnerLabel} {
 		if !strings.Contains(body, expectedSnippet) {
 			t.Fatalf("expected body to contain %q", expectedSnippet)
 		}


### PR DESCRIPTION
## Summary
- add an UploadSummary model with JSON tags so owner labels flow through comparison data
- surface upload summaries in the overview template and matrix JSON for clients
- teach the frontend script and router tests to expect the new ownerLabel property

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cb26ed754883279d183b345e0d7e07