### PR TITLE
Add optional Twitter integration test

### DIFF
--- a/internal/handles/intent_fetcher.go
+++ b/internal/handles/intent_fetcher.go
@@ -1,0 +1,235 @@
+package handles
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	chromeBinaryEnvironmentVariable      = "CHROME_BIN"
+	defaultChromeUserAgent               = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+	chromeUserAgentFlagFormat            = "--user-agent=%s"
+	chromeVirtualTimeBudgetFlagFormat    = "--virtual-time-budget=%d"
+	chromeDumpDOMFlag                    = "--dump-dom"
+	chromeHeadlessFlag                   = "--headless=new"
+	chromeDisableGPUFlag                 = "--disable-gpu"
+	chromeUseGLSwiftShaderFlag           = "--use-gl=swiftshader"
+	chromeEnableUnsafeSwiftShaderFlag    = "--enable-unsafe-swiftshader"
+	chromeHideScrollbarsFlag             = "--hide-scrollbars"
+	chromeNoFirstRunFlag                 = "--no-first-run"
+	chromeNoDefaultBrowserCheckFlag      = "--no-default-browser-check"
+	chromeLogLevelFlag                   = "--log-level=3"
+	chromeSilentFlag                     = "--silent"
+	chromeDisableLoggingFlag             = "--disable-logging"
+	chromeDisableGPUStartupFlag          = "--disable-gpu-startup"
+	chromeVirtualTimeBudgetDefaultMillis = 15000
+	chromeRequestDelayDefaultMillis      = 500
+	chromeBinaryPathMacOS                = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+	chromeBinaryPathLinux                = "/usr/bin/google-chrome"
+	chromeBinaryNameLinux                = "google-chrome"
+	chromeBinaryPathChromium             = "/usr/bin/chromium"
+	chromeBinaryNameChromium             = "chromium"
+	chromeBinaryFallback                 = chromeBinaryNameLinux
+	errMessageMissingChromeBinaryPath    = "chrome binary path could not be determined"
+
+	// ChromeBinaryEnvironmentVariable exposes the environment variable name used to
+	// locate a Chrome binary for intent resolution.
+	ChromeBinaryEnvironmentVariable = chromeBinaryEnvironmentVariable
+)
+
+var (
+	baseChromeArguments = []string{
+		chromeHeadlessFlag,
+		chromeDisableGPUFlag,
+		chromeDisableGPUStartupFlag,
+		chromeUseGLSwiftShaderFlag,
+		chromeEnableUnsafeSwiftShaderFlag,
+		chromeHideScrollbarsFlag,
+		chromeNoFirstRunFlag,
+		chromeNoDefaultBrowserCheckFlag,
+		chromeLogLevelFlag,
+		chromeSilentFlag,
+		chromeDisableLoggingFlag,
+	}
+
+	defaultChromeBinaryCandidates = []string{
+		chromeBinaryPathMacOS,
+		chromeBinaryPathLinux,
+		chromeBinaryNameLinux,
+		chromeBinaryPathChromium,
+		chromeBinaryNameChromium,
+	}
+)
+
+// IntentRequest describes the request to fetch an intent page for a numeric account identifier.
+type IntentRequest struct {
+	AccountID string
+	URL       string
+}
+
+// IntentPage captures the rendered HTML for a Twitter intent page.
+type IntentPage struct {
+	HTML      string
+	SourceURL string
+}
+
+// IntentFetcher retrieves rendered intent pages.
+type IntentFetcher interface {
+	FetchIntentPage(ctx context.Context, request IntentRequest) (IntentPage, error)
+}
+
+// ChromeFetcherConfig configures a ChromeIntentFetcher instance.
+type ChromeFetcherConfig struct {
+	BinaryPath        string
+	UserAgent         string
+	VirtualTimeBudget time.Duration
+	RequestDelay      time.Duration
+}
+
+// ChromeIntentFetcher renders intent pages using a headless Chrome invocation.
+type ChromeIntentFetcher struct {
+	chromeBinaryPath  string
+	userAgent         string
+	virtualTimeBudget time.Duration
+	requestDelay      time.Duration
+
+	executionMutex sync.Mutex
+	lastInvocation time.Time
+}
+
+// NewChromeIntentFetcher constructs a ChromeIntentFetcher from configuration values.
+func NewChromeIntentFetcher(configuration ChromeFetcherConfig) (*ChromeIntentFetcher, error) {
+	trimmedBinaryPath := strings.TrimSpace(configuration.BinaryPath)
+	if trimmedBinaryPath == "" {
+		return nil, fmt.Errorf(errMessageMissingChromeBinaryPath)
+	}
+
+	userAgent := strings.TrimSpace(configuration.UserAgent)
+	if userAgent == "" {
+		userAgent = defaultChromeUserAgent
+	}
+
+	virtualTimeBudget := configuration.VirtualTimeBudget
+	if virtualTimeBudget <= 0 {
+		virtualTimeBudget = time.Duration(chromeVirtualTimeBudgetDefaultMillis) * time.Millisecond
+	}
+
+	requestDelay := configuration.RequestDelay
+	if requestDelay < 0 {
+		requestDelay = 0
+	} else if requestDelay == 0 {
+		requestDelay = time.Duration(chromeRequestDelayDefaultMillis) * time.Millisecond
+	}
+
+	fetcher := &ChromeIntentFetcher{
+		chromeBinaryPath:  trimmedBinaryPath,
+		userAgent:         userAgent,
+		virtualTimeBudget: virtualTimeBudget,
+		requestDelay:      requestDelay,
+	}
+	return fetcher, nil
+}
+
+// FetchIntentPage renders the provided intent URL using headless Chrome.
+func (fetcher *ChromeIntentFetcher) FetchIntentPage(ctx context.Context, request IntentRequest) (IntentPage, error) {
+	fetcher.executionMutex.Lock()
+	defer fetcher.executionMutex.Unlock()
+
+	fetcher.enforceDelay()
+	defer fetcher.recordInvocation()
+
+	htmlContent, renderErr := fetcher.renderIntentPage(ctx, request.URL)
+	if renderErr != nil {
+		return IntentPage{}, renderErr
+	}
+	if strings.TrimSpace(htmlContent) == "" {
+		return IntentPage{}, fmt.Errorf("%w: %s", errEmptyIntentHTML, request.URL)
+	}
+
+	return IntentPage{HTML: htmlContent, SourceURL: request.URL}, nil
+}
+
+func (fetcher *ChromeIntentFetcher) enforceDelay() {
+	if fetcher.requestDelay <= 0 {
+		return
+	}
+	if fetcher.lastInvocation.IsZero() {
+		return
+	}
+	elapsed := time.Since(fetcher.lastInvocation)
+	if elapsed < fetcher.requestDelay {
+		time.Sleep(fetcher.requestDelay - elapsed)
+	}
+}
+
+func (fetcher *ChromeIntentFetcher) recordInvocation() {
+	fetcher.lastInvocation = time.Now()
+}
+
+func (fetcher *ChromeIntentFetcher) renderIntentPage(ctx context.Context, requestURL string) (string, error) {
+	commandArguments := fetcher.buildCommandArguments(requestURL)
+	command := exec.CommandContext(ctx, fetcher.chromeBinaryPath, commandArguments...)
+	var stdout bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = io.Discard
+
+	if startErr := command.Start(); startErr != nil {
+		return "", startErr
+	}
+
+	waitChannel := make(chan error, 1)
+	go func() {
+		waitChannel <- command.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+		_ = command.Process.Kill()
+		<-waitChannel
+		return "", ctx.Err()
+	case waitErr := <-waitChannel:
+		if waitErr != nil {
+			return "", waitErr
+		}
+		return stdout.String(), nil
+	}
+}
+
+func (fetcher *ChromeIntentFetcher) buildCommandArguments(requestURL string) []string {
+	arguments := append([]string{}, baseChromeArguments...)
+	userAgentArgument := fmt.Sprintf(chromeUserAgentFlagFormat, fetcher.userAgent)
+	arguments = append(arguments, userAgentArgument)
+	if fetcher.virtualTimeBudget > 0 {
+		budgetMillis := int(fetcher.virtualTimeBudget / time.Millisecond)
+		arguments = append(arguments, fmt.Sprintf(chromeVirtualTimeBudgetFlagFormat, budgetMillis))
+	}
+	arguments = append(arguments, chromeDumpDOMFlag, requestURL)
+	return arguments
+}
+
+func resolveChromeBinaryPath(configuration Config) string {
+	if trimmed := strings.TrimSpace(configuration.ChromeBinaryPath); trimmed != "" {
+		return trimmed
+	}
+	if environmentValue := strings.TrimSpace(os.Getenv(ChromeBinaryEnvironmentVariable)); environmentValue != "" {
+		return environmentValue
+	}
+	for _, candidate := range defaultChromeBinaryCandidates {
+		if resolvedPath, lookErr := exec.LookPath(candidate); lookErr == nil {
+			return resolvedPath
+		}
+	}
+	return chromeBinaryFallback
+}
+
+// ResolveChromeBinaryPath determines the Chrome binary path for the supplied configuration.
+func ResolveChromeBinaryPath(configuration Config) string {
+	return resolveChromeBinaryPath(configuration)
+}

--- a/internal/handles/resolver_test.go
+++ b/internal/handles/resolver_test.go
@@ -1,0 +1,344 @@
+package handles_test
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/f-sync/fsync/internal/handles"
+)
+
+const (
+	resolverTestIntentHTMLSuccess          = "<html><head><title>Example Name (@example) / X</title></head><body><a href=\"https://x.com/example\">profile</a></body></html>"
+	resolverTestIntentHTMLMissingHandle    = "<html><head><title>Example Name (@example) / X</title></head><body>No links</body></html>"
+	resolverTestIntentHTMLNoTitle          = "<html><body><a href=\"https://x.com/example\">profile</a></body></html>"
+	resolverTestIntentURLPrefix            = "https://x.com/intent/user?user_id="
+	resolverTestErrorMessageMissingAccount = "no stub intent response for account"
+
+	resolverTestAccountIDSuccess           = "10001"
+	resolverTestAccountIDMissingHandle     = "10002"
+	resolverTestAccountIDNoTitle           = "10003"
+	resolverTestAccountIDFetcherError      = "10004"
+	resolverTestAccountIDPrimaryDedup      = "20001"
+	resolverTestAccountIDSecondaryDedup    = "20002"
+	resolverTestAccountIDCacheReuse        = "20003"
+	resolverTestAccountIDSharedAcrossCache = "20004"
+
+	resolverIntegrationFlagName                 = "twitter_integration"
+	resolverIntegrationFlagDescription          = "enable live Twitter intent resolution integration test"
+	resolverIntegrationFlagDisabledMessage      = "twitter integration test skipped because the flag is disabled"
+	resolverIntegrationChromeUnavailableMessage = "twitter integration test skipped because no Chrome binary is available"
+	resolverIntegrationTestCaseNameElon         = "elon musk intent resolution"
+	resolverIntegrationAccountIDElon            = "44196397"
+	resolverIntegrationExpectedUserNameElon     = "elonmusk"
+	resolverIntegrationCreateResolverError      = "create integration resolver"
+	resolverIntegrationResolveErrorFormat       = "integration resolver returned error: %v"
+	resolverIntegrationUnexpectedHandleFormat   = "expected integration handle %s, got %s"
+	resolverIntegrationEmptyDisplayNameMessage  = "expected integration display name to be non-empty"
+	resolverIntegrationSkipMessageFormat        = "%s: %v"
+	resolverIntegrationErrMessageEmptyChrome    = "resolved empty chrome binary path"
+	resolverIntegrationContextTimeoutSeconds    = 30
+)
+
+var (
+	resolverIntegrationRunFlag = flag.Bool(resolverIntegrationFlagName, false, resolverIntegrationFlagDescription)
+
+	resolverIntegrationRequestTimeout = time.Duration(resolverIntegrationContextTimeoutSeconds) * time.Second
+)
+
+type recordingIntentFetcher struct {
+	responses map[string]handles.IntentPage
+	errors    map[string]error
+	mu        sync.Mutex
+	calls     map[string]int
+}
+
+func newRecordingIntentFetcher(responses map[string]handles.IntentPage, errors map[string]error) *recordingIntentFetcher {
+	return &recordingIntentFetcher{
+		responses: responses,
+		errors:    errors,
+		calls:     make(map[string]int),
+	}
+}
+
+func resolverIntegrationChromeBinaryPath() (string, error) {
+	resolvedPath := handles.ResolveChromeBinaryPath(handles.Config{})
+	trimmedPath := strings.TrimSpace(resolvedPath)
+	if trimmedPath == "" {
+		return "", errors.New(resolverIntegrationErrMessageEmptyChrome)
+	}
+	if strings.ContainsRune(trimmedPath, os.PathSeparator) {
+		if _, statErr := os.Stat(trimmedPath); statErr != nil {
+			return "", statErr
+		}
+		return trimmedPath, nil
+	}
+	lookedPath, lookErr := exec.LookPath(trimmedPath)
+	if lookErr != nil {
+		return "", lookErr
+	}
+	return lookedPath, nil
+}
+
+func (fetcher *recordingIntentFetcher) FetchIntentPage(ctx context.Context, request handles.IntentRequest) (handles.IntentPage, error) {
+	fetcher.mu.Lock()
+	fetcher.calls[request.AccountID]++
+	fetcher.mu.Unlock()
+
+	if fetchErr, exists := fetcher.errors[request.AccountID]; exists {
+		return handles.IntentPage{}, fetchErr
+	}
+	if response, exists := fetcher.responses[request.AccountID]; exists {
+		return response, nil
+	}
+	return handles.IntentPage{}, fmt.Errorf("%s %s", resolverTestErrorMessageMissingAccount, request.AccountID)
+}
+
+func TestResolverResolveAccount(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                string
+		accountID           string
+		htmlContent         string
+		fetchError          error
+		expectError         bool
+		expectedUserName    string
+		expectedDisplayName string
+	}{
+		{
+			name:                "successful resolution",
+			accountID:           resolverTestAccountIDSuccess,
+			htmlContent:         resolverTestIntentHTMLSuccess,
+			expectedUserName:    "example",
+			expectedDisplayName: "Example Name",
+		},
+		{
+			name:        "missing handle",
+			accountID:   resolverTestAccountIDMissingHandle,
+			htmlContent: resolverTestIntentHTMLMissingHandle,
+			expectError: true,
+		},
+		{
+			name:                "no title retains empty display name",
+			accountID:           resolverTestAccountIDNoTitle,
+			htmlContent:         resolverTestIntentHTMLNoTitle,
+			expectedUserName:    "example",
+			expectedDisplayName: "",
+		},
+		{
+			name:        "fetcher returns error",
+			accountID:   resolverTestAccountIDFetcherError,
+			fetchError:  fmt.Errorf("fetch failure"),
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			responses := make(map[string]handles.IntentPage)
+			errors := make(map[string]error)
+			if testCase.htmlContent != "" {
+				responses[testCase.accountID] = handles.IntentPage{HTML: testCase.htmlContent, SourceURL: resolverTestIntentURLPrefix + testCase.accountID}
+			}
+			if testCase.fetchError != nil {
+				errors[testCase.accountID] = testCase.fetchError
+			}
+			fetcher := newRecordingIntentFetcher(responses, errors)
+			resolver, err := handles.NewResolver(handles.Config{IntentFetcher: fetcher, MaxConcurrent: 2})
+			if err != nil {
+				t.Fatalf("create resolver: %v", err)
+			}
+
+			record, resolveErr := resolver.ResolveAccount(context.Background(), testCase.accountID)
+			if testCase.expectError {
+				if resolveErr == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if resolveErr != nil {
+				t.Fatalf("unexpected error: %v", resolveErr)
+			}
+			if record.UserName != testCase.expectedUserName {
+				t.Fatalf("unexpected username: %s", record.UserName)
+			}
+			if record.DisplayName != testCase.expectedDisplayName {
+				t.Fatalf("unexpected display name: %s", record.DisplayName)
+			}
+			if record.AccountID != testCase.accountID {
+				t.Fatalf("unexpected account id: %s", record.AccountID)
+			}
+		})
+	}
+}
+
+func TestResolverResolveManyDeduplicates(t *testing.T) {
+	accountResponses := map[string]handles.IntentPage{
+		resolverTestAccountIDPrimaryDedup: {
+			HTML:      resolverTestIntentHTMLSuccess,
+			SourceURL: resolverTestIntentURLPrefix + resolverTestAccountIDPrimaryDedup,
+		},
+		resolverTestAccountIDSecondaryDedup: {
+			HTML:      strings.ReplaceAll(resolverTestIntentHTMLSuccess, "example", "second"),
+			SourceURL: resolverTestIntentURLPrefix + resolverTestAccountIDSecondaryDedup,
+		},
+	}
+	fetcher := newRecordingIntentFetcher(accountResponses, nil)
+	resolver, err := handles.NewResolver(handles.Config{IntentFetcher: fetcher, MaxConcurrent: 3})
+	if err != nil {
+		t.Fatalf("create resolver: %v", err)
+	}
+
+	accountIDs := []string{
+		resolverTestAccountIDPrimaryDedup,
+		resolverTestAccountIDPrimaryDedup,
+		resolverTestAccountIDSecondaryDedup,
+		"",
+		resolverTestAccountIDSecondaryDedup,
+	}
+	results := resolver.ResolveMany(context.Background(), accountIDs)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if fetcher.calls[resolverTestAccountIDPrimaryDedup] != 1 {
+		t.Fatalf("expected single fetch for account %s, got %d", resolverTestAccountIDPrimaryDedup, fetcher.calls[resolverTestAccountIDPrimaryDedup])
+	}
+	if fetcher.calls[resolverTestAccountIDSecondaryDedup] != 1 {
+		t.Fatalf("expected single fetch for account %s, got %d", resolverTestAccountIDSecondaryDedup, fetcher.calls[resolverTestAccountIDSecondaryDedup])
+	}
+}
+
+func TestResolverCachesResults(t *testing.T) {
+	fetcher := newRecordingIntentFetcher(map[string]handles.IntentPage{
+		resolverTestAccountIDCacheReuse: {
+			HTML:      resolverTestIntentHTMLSuccess,
+			SourceURL: resolverTestIntentURLPrefix + resolverTestAccountIDCacheReuse,
+		},
+	}, nil)
+	resolver, err := handles.NewResolver(handles.Config{IntentFetcher: fetcher, MaxConcurrent: 2})
+	if err != nil {
+		t.Fatalf("create resolver: %v", err)
+	}
+
+	_, firstErr := resolver.ResolveAccount(context.Background(), resolverTestAccountIDCacheReuse)
+	if firstErr != nil {
+		t.Fatalf("first resolution failed: %v", firstErr)
+	}
+	_, secondErr := resolver.ResolveAccount(context.Background(), resolverTestAccountIDCacheReuse)
+	if secondErr != nil {
+		t.Fatalf("second resolution failed: %v", secondErr)
+	}
+	if fetcher.calls[resolverTestAccountIDCacheReuse] != 1 {
+		t.Fatalf("expected cached response to avoid duplicate fetch, got %d calls", fetcher.calls[resolverTestAccountIDCacheReuse])
+	}
+}
+
+func TestResolverSharesCacheAcrossInstances(t *testing.T) {
+	testCases := []struct {
+		name string
+	}{
+		{
+			name: "shared cache prevents duplicate fetches",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			firstFetcher := newRecordingIntentFetcher(map[string]handles.IntentPage{
+				resolverTestAccountIDSharedAcrossCache: {
+					HTML:      resolverTestIntentHTMLSuccess,
+					SourceURL: resolverTestIntentURLPrefix + resolverTestAccountIDSharedAcrossCache,
+				},
+			}, nil)
+			firstResolver, err := handles.NewResolver(handles.Config{IntentFetcher: firstFetcher, MaxConcurrent: 2})
+			if err != nil {
+				t.Fatalf("create first resolver: %v", err)
+			}
+
+			firstRecord, firstErr := firstResolver.ResolveAccount(context.Background(), resolverTestAccountIDSharedAcrossCache)
+			if firstErr != nil {
+				t.Fatalf("first resolver failed: %v", firstErr)
+			}
+
+			secondFetcher := newRecordingIntentFetcher(map[string]handles.IntentPage{}, nil)
+			secondResolver, err := handles.NewResolver(handles.Config{IntentFetcher: secondFetcher, MaxConcurrent: 2})
+			if err != nil {
+				t.Fatalf("create second resolver: %v", err)
+			}
+
+			secondRecord, secondErr := secondResolver.ResolveAccount(context.Background(), resolverTestAccountIDSharedAcrossCache)
+			if secondErr != nil {
+				t.Fatalf("second resolver returned error: %v", secondErr)
+			}
+			if secondFetcher.calls[resolverTestAccountIDSharedAcrossCache] != 0 {
+				t.Fatalf("expected shared cache to prevent second fetch, observed %d calls", secondFetcher.calls[resolverTestAccountIDSharedAcrossCache])
+			}
+			if secondRecord.UserName != firstRecord.UserName {
+				t.Fatalf("expected cached username %s, got %s", firstRecord.UserName, secondRecord.UserName)
+			}
+			if secondRecord.DisplayName != firstRecord.DisplayName {
+				t.Fatalf("expected cached display name %s, got %s", firstRecord.DisplayName, secondRecord.DisplayName)
+			}
+		})
+	}
+}
+
+func TestResolverIntegrationResolveElonMusk(t *testing.T) {
+	if !*resolverIntegrationRunFlag {
+		t.Skip(resolverIntegrationFlagDisabledMessage)
+	}
+
+	chromeBinaryPath, chromeErr := resolverIntegrationChromeBinaryPath()
+	if chromeErr != nil {
+		t.Skipf(resolverIntegrationSkipMessageFormat, resolverIntegrationChromeUnavailableMessage, chromeErr)
+	}
+
+	resolver, err := handles.NewResolver(handles.Config{ChromeBinaryPath: chromeBinaryPath})
+	if err != nil {
+		t.Fatalf(resolverIntegrationSkipMessageFormat, resolverIntegrationCreateResolverError, err)
+	}
+
+	testCases := []struct {
+		name             string
+		accountID        string
+		expectedUserName string
+	}{
+		{
+			name:             resolverIntegrationTestCaseNameElon,
+			accountID:        resolverIntegrationAccountIDElon,
+			expectedUserName: resolverIntegrationExpectedUserNameElon,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), resolverIntegrationRequestTimeout)
+			defer cancel()
+
+			record, resolveErr := resolver.ResolveAccount(ctx, testCase.accountID)
+			if resolveErr != nil {
+				if errors.Is(resolveErr, exec.ErrNotFound) {
+					t.Skipf(resolverIntegrationSkipMessageFormat, resolverIntegrationChromeUnavailableMessage, resolveErr)
+				}
+				t.Fatalf(resolverIntegrationResolveErrorFormat, resolveErr)
+			}
+			if record.UserName != testCase.expectedUserName {
+				t.Fatalf(resolverIntegrationUnexpectedHandleFormat, testCase.expectedUserName, record.UserName)
+			}
+			if strings.TrimSpace(record.DisplayName) == "" {
+				t.Fatalf(resolverIntegrationEmptyDisplayNameMessage)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- expose the Chrome binary environment constant and helper so callers can reuse the default path resolution logic
- add a flag-gated integration test that resolves Elon Musk's handle via a real intent request when Chrome is available

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68cb7ad17f7883278ae17b19b4c8b1a0