### PR TITLE
Enhance xresolve intent parsing

### DIFF
--- a/internal/intentparser/doc.go
+++ b/internal/intentparser/doc.go
@@ -1,0 +1,2 @@
+// Package intentparser extracts handle and display name information from Twitter intent HTML pages.
+package intentparser

--- a/internal/intentparser/parser.go
+++ b/internal/intentparser/parser.go
@@ -1,0 +1,136 @@
+package intentparser
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+const (
+	profileURLPattern           = `https://(?:x|twitter)\.com/([A-Za-z0-9_]{1,15})`
+	htmlSingleQuoteCharacter    = "'"
+	htmlDoubleQuoteCharacter    = `"`
+	titleStartTag               = "<title>"
+	titleEndTag                 = "</title>"
+	whitespaceCharacters        = " \t\r\n"
+	errMessageMissingHandle     = "twitter intent page did not contain a handle"
+	reservedHandlePathAnalytics = "i"
+	reservedHandlePathIntent    = "intent"
+	reservedHandlePathHome      = "home"
+	reservedHandlePathTerms     = "tos"
+	reservedHandlePathPrivacy   = "privacy"
+	reservedHandlePathExplore   = "explore"
+	reservedHandlePathNotices   = "notifications"
+	reservedHandlePathSettings  = "settings"
+	reservedHandlePathLogin     = "login"
+	reservedHandlePathSignup    = "signup"
+	reservedHandlePathShare     = "share"
+	reservedHandlePathAccount   = "account"
+	reservedHandlePathCompose   = "compose"
+	reservedHandlePathMessages  = "messages"
+	reservedHandlePathSearch    = "search"
+	displayNameSuffixSlashX     = " / X"
+	displayNameSuffixOnX        = " on X"
+	handleTokenPrefix           = "(@"
+	handleTokenSuffix           = ")"
+)
+
+var (
+	// ErrMissingHandle indicates that an intent page did not expose a handle.
+	ErrMissingHandle = errors.New(errMessageMissingHandle)
+
+	profileURLRegex = regexp.MustCompile(profileURLPattern)
+
+	reservedHandleNames = map[string]struct{}{
+		reservedHandlePathAnalytics: {},
+		reservedHandlePathIntent:    {},
+		reservedHandlePathHome:      {},
+		reservedHandlePathTerms:     {},
+		reservedHandlePathPrivacy:   {},
+		reservedHandlePathExplore:   {},
+		reservedHandlePathNotices:   {},
+		reservedHandlePathSettings:  {},
+		reservedHandlePathLogin:     {},
+		reservedHandlePathSignup:    {},
+		reservedHandlePathShare:     {},
+		reservedHandlePathAccount:   {},
+		reservedHandlePathCompose:   {},
+		reservedHandlePathMessages:  {},
+		reservedHandlePathSearch:    {},
+	}
+)
+
+// IntentHTMLParser extracts handle and display name data from Twitter intent HTML.
+type IntentHTMLParser struct {
+	htmlContent string
+}
+
+// NewIntentHTMLParser constructs a parser for the provided HTML content.
+func NewIntentHTMLParser(htmlContent string) IntentHTMLParser {
+	normalizedHTML := strings.ReplaceAll(htmlContent, htmlSingleQuoteCharacter, htmlDoubleQuoteCharacter)
+	return IntentHTMLParser{htmlContent: normalizedHTML}
+}
+
+// ExtractHandle returns the first non-reserved handle found in the HTML.
+func (parser IntentHTMLParser) ExtractHandle() (string, error) {
+	matches := profileURLRegex.FindAllStringSubmatch(parser.htmlContent, -1)
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		candidate := strings.TrimSpace(match[1])
+		if candidate == "" {
+			continue
+		}
+		if parser.isReservedHandle(candidate) {
+			continue
+		}
+		return candidate, nil
+	}
+	return "", ErrMissingHandle
+}
+
+// ExtractDisplayName derives the display name from the HTML <title> tag.
+func (parser IntentHTMLParser) ExtractDisplayName(handle string) string {
+	titleContent := parser.titleTagContent()
+	if titleContent == "" {
+		return ""
+	}
+	cleanedTitle := trimDisplayNameSuffixes(titleContent)
+	if handle != "" {
+		handleToken := handleTokenPrefix + handle + handleTokenSuffix
+		cleanedTitle = strings.ReplaceAll(cleanedTitle, handleToken, "")
+		cleanedTitle = trimDisplayNameSuffixes(cleanedTitle)
+	}
+	return strings.Trim(cleanedTitle, whitespaceCharacters)
+}
+
+func (parser IntentHTMLParser) isReservedHandle(handle string) bool {
+	_, reserved := reservedHandleNames[strings.ToLower(handle)]
+	return reserved
+}
+
+func (parser IntentHTMLParser) titleTagContent() string {
+	startIndex := strings.Index(parser.htmlContent, titleStartTag)
+	if startIndex == -1 {
+		return ""
+	}
+	startIndex += len(titleStartTag)
+	endIndex := strings.Index(parser.htmlContent[startIndex:], titleEndTag)
+	if endIndex == -1 {
+		return ""
+	}
+	endIndex += startIndex
+	return strings.Trim(parser.htmlContent[startIndex:endIndex], whitespaceCharacters)
+}
+
+func trimDisplayNameSuffixes(titleContent string) string {
+	trimmed := strings.Trim(titleContent, whitespaceCharacters)
+	if strings.HasSuffix(trimmed, displayNameSuffixSlashX) {
+		trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, displayNameSuffixSlashX))
+	}
+	if strings.HasSuffix(trimmed, displayNameSuffixOnX) {
+		trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, displayNameSuffixOnX))
+	}
+	return trimmed
+}

--- a/internal/intentparser/parser_test.go
+++ b/internal/intentparser/parser_test.go
@@ -1,0 +1,102 @@
+package intentparser_test
+
+import (
+	"testing"
+
+	"github.com/f-sync/fsync/internal/intentparser"
+)
+
+const (
+	sampleIntentHTML          = `<html><head><title>Example Name (@example) / X</title></head><body><a href="https://x.com/example">profile</a></body></html>`
+	reservedIntentHTML        = `<html><head><title>Reserved Path (@example) / X</title></head><body><a href="https://x.com/intent">intent</a><a href="https://x.com/realhandle">profile</a></body></html>`
+	missingHandleIntentHTML   = `<html><head><title>Unknown / X</title></head><body></body></html>`
+	onXTitleIntentHTML        = `<html><head><title>Example On X (@example) on X</title></head><body><a href="https://x.com/example">profile</a></body></html>`
+	handleFreeTitleIntentHTML = `<html><head><title>Plain Example / X</title></head><body><a href="https://x.com/example">profile</a></body></html>`
+)
+
+func TestIntentHTMLParserExtractHandle(t *testing.T) {
+	testCases := []struct {
+		name           string
+		htmlContent    string
+		expectedHandle string
+		expectError    bool
+	}{
+		{
+			name:           "extracts handle from profile url",
+			htmlContent:    sampleIntentHTML,
+			expectedHandle: "example",
+		},
+		{
+			name:           "skips reserved paths",
+			htmlContent:    reservedIntentHTML,
+			expectedHandle: "realhandle",
+		},
+		{
+			name:        "missing handle returns error",
+			htmlContent: missingHandleIntentHTML,
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			parser := intentparser.NewIntentHTMLParser(testCase.htmlContent)
+			handle, err := parser.ExtractHandle()
+			if testCase.expectError {
+				if err == nil {
+					t.Fatalf("expected error extracting handle")
+				}
+				if err != intentparser.ErrMissingHandle {
+					t.Fatalf("unexpected error type: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if handle != testCase.expectedHandle {
+				t.Fatalf("expected handle %s, got %s", testCase.expectedHandle, handle)
+			}
+		})
+	}
+}
+
+func TestIntentHTMLParserExtractDisplayName(t *testing.T) {
+	testCases := []struct {
+		name            string
+		htmlContent     string
+		handle          string
+		expectedDisplay string
+	}{
+		{
+			name:            "trims slash suffix",
+			htmlContent:     sampleIntentHTML,
+			handle:          "example",
+			expectedDisplay: "Example Name",
+		},
+		{
+			name:            "removes on x suffix",
+			htmlContent:     onXTitleIntentHTML,
+			handle:          "example",
+			expectedDisplay: "Example On X",
+		},
+		{
+			name:            "handles empty handle argument",
+			htmlContent:     handleFreeTitleIntentHTML,
+			handle:          "",
+			expectedDisplay: "Plain Example",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			parser := intentparser.NewIntentHTMLParser(testCase.htmlContent)
+			displayName := parser.ExtractDisplayName(testCase.handle)
+			if displayName != testCase.expectedDisplay {
+				t.Fatalf("expected display name %s, got %s", testCase.expectedDisplay, displayName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add intent HTML fetching to xresolve, storing display names and updating CLI/CSV output
- factor intent HTML parsing into a shared internal package used by both xresolve and the handles resolver
- cover the new parser with table-driven unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cc437f89e08327bb76ff210bf61732