### PR TITLE
Enable default handle resolution in server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ F-Sync compares relationship exports from two Twitter archive ZIP files and rend
 
 ## HTTP server mode
 
-You can launch an HTTP server that renders the comparison interface on demand. Provide the paths to the two exported ZIP files and optionally enable handle resolution against twitter.com:
+You can launch an HTTP server that renders the comparison interface on demand. Provide the paths to the two exported ZIP files:
 
 ```bash
 go run ./cmd/server --zip-a /path/to/first.zip --zip-b /path/to/second.zip --port 8080
 ```
 
-The server listens on `127.0.0.1` by default; use `--host` to override the bind address. Add `--resolve-handles` to fetch missing handles over HTTPS before rendering the page.
+The server listens on `127.0.0.1` by default; use `--host` to override the bind address. The server always resolves missing handles before rendering; ensure that Google Chrome or Chromium is installed and discoverable via the `PATH` or `CHROME_BIN` environment variable so the resolver can launch a headless browser session.
 
 Health information is available at `http://<host>:<port>/healthz`, and the rendered comparison is served at the root path.

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -84,7 +84,6 @@ type RouterConfig struct {
 	Service        ComparisonService
 	Store          ComparisonStore
 	Logger         *zap.Logger
-	ResolveHandles bool
 	HandleResolver matrix.AccountHandleResolver
 }
 
@@ -138,7 +137,6 @@ func NewRouter(configuration RouterConfig) (*gin.Engine, error) {
 		store:          store,
 		service:        service,
 		logger:         logger,
-		resolveHandles: configuration.ResolveHandles,
 		handleResolver: configuration.HandleResolver,
 	}
 
@@ -154,7 +152,6 @@ type applicationHandler struct {
 	store          ComparisonStore
 	service        ComparisonService
 	logger         *zap.Logger
-	resolveHandles bool
 	handleResolver matrix.AccountHandleResolver
 }
 
@@ -234,7 +231,7 @@ func (handler applicationHandler) uploadArchives(ginContext *gin.Context) {
 		}
 	}
 
-	if handler.resolveHandles && handler.handleResolver != nil && snapshot.ComparisonData != nil {
+	if handler.handleResolver != nil && snapshot.ComparisonData != nil {
 		handler.logger.Info(logMessageHandleResolution)
 		go handler.resolveHandlesAsync()
 	}


### PR DESCRIPTION
## Summary
- always initialize the handle resolver when starting the server and remove the optional flag
- trigger asynchronous handle resolution whenever comparison data is available and add coverage for the behavior
- document that Chrome/Chromium is required now that handle resolution runs by default

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cc54fd6da88327a211523635239c7a