### PR TITLE
Enforce handle resolution when a resolver is available

### DIFF
--- a/cmd/dump/main.go
+++ b/cmd/dump/main.go
@@ -55,7 +55,7 @@ func main() {
 	if err != nil {
 		dief(handlesResolverErrorFormat, err)
 	}
-	resolutionErrors := matrix.MaybeResolveHandles(context.Background(), resolver, true, &accountSetsA, &accountSetsB)
+	resolutionErrors := matrix.ResolveHandles(context.Background(), resolver, &accountSetsA, &accountSetsB)
 	for accountID, resolutionErr := range resolutionErrors {
 		fmt.Fprintf(os.Stderr, handleResolutionErrorFormat, accountID, resolutionErr)
 	}

--- a/internal/matrix/handles.go
+++ b/internal/matrix/handles.go
@@ -3,7 +3,6 @@ package matrix
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/f-sync/fsync/internal/handles"
 )
@@ -22,9 +21,9 @@ type accountResolutionTarget struct {
 	records map[string]AccountRecord
 }
 
-// MaybeResolveHandles enriches account sets with resolved handles when enabled.
-func MaybeResolveHandles(ctx context.Context, resolver AccountHandleResolver, shouldResolve bool, accountSets ...*AccountSets) map[string]error {
-	if !shouldResolve || resolver == nil {
+// ResolveHandles enriches account sets with resolved handles whenever a resolver is provided.
+func ResolveHandles(ctx context.Context, resolver AccountHandleResolver, accountSets ...*AccountSets) map[string]error {
+	if resolver == nil {
 		return nil
 	}
 
@@ -59,12 +58,8 @@ func MaybeResolveHandles(ctx context.Context, resolver AccountHandleResolver, sh
 		}
 		for _, target := range accountIDTargets[accountID] {
 			record := target.records[accountID]
-			if record.UserName == "" {
-				record.UserName = result.Record.UserName
-			}
-			if record.DisplayName == "" {
-				record.DisplayName = result.Record.DisplayName
-			}
+			record.UserName = result.Record.UserName
+			record.DisplayName = result.Record.DisplayName
 			target.records[accountID] = record
 		}
 	}
@@ -75,10 +70,7 @@ func MaybeResolveHandles(ctx context.Context, resolver AccountHandleResolver, sh
 }
 
 func collectResolutionTargets(source map[string]AccountRecord, targets map[string][]accountResolutionTarget) {
-	for accountID, record := range source {
-		if strings.TrimSpace(record.UserName) != "" {
-			continue
-		}
+	for accountID := range source {
 		targets[accountID] = append(targets[accountID], accountResolutionTarget{records: source})
 	}
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -363,7 +363,7 @@ func (store *memoryComparisonStore) ResolveHandles(ctx context.Context, resolver
 
 	accountSetsPrimary := copyAccountSets(primary.accountSets)
 	accountSetsSecondary := copyAccountSets(secondary.accountSets)
-	errorsByAccountID := matrix.MaybeResolveHandles(ctx, resolver, true, &accountSetsPrimary, &accountSetsSecondary)
+	errorsByAccountID := matrix.ResolveHandles(ctx, resolver, &accountSetsPrimary, &accountSetsSecondary)
 
 	store.mutex.Lock()
 	if store.primary != nil && (sameOwner(store.primary.owner, primary.owner) || sameFileForUnknownOwner(*store.primary, primary)) {


### PR DESCRIPTION
## Summary
- replace the conditional MaybeResolveHandles helper with an always-on ResolveHandles variant
- update the server store, CLI dump command, and matrix tests to consume the new API
- ensure resolved handles overwrite existing archival usernames and display names for consistent UI output

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cc94bcd27c8327b81ff84ed3a317d7