### PR TITLE
Ensure dump CLI always resolves handles

### DIFF
--- a/cmd/dump/application.go
+++ b/cmd/dump/application.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/f-sync/fsync/internal/handles"
+	"github.com/f-sync/fsync/internal/matrix"
+)
+
+type DumpConfiguration struct {
+	ZipPathA   string
+	ZipPathB   string
+	OutputPath string
+}
+
+type DumpDependencies struct {
+	ReadArchive      func(string) (matrix.AccountSets, matrix.OwnerIdentity, error)
+	BuildResolver    func() (matrix.AccountHandleResolver, error)
+	RenderComparison func(matrix.ComparisonPageData) (string, error)
+	WriteOutputFile  func(string, string) error
+	Stdout           io.Writer
+	Stderr           io.Writer
+}
+
+type DumpApplication struct {
+	dependencies DumpDependencies
+}
+
+func NewDumpApplication() DumpApplication {
+	return NewDumpApplicationWithDependencies(newDefaultDumpDependencies())
+}
+
+func NewDumpApplicationWithDependencies(dependencies DumpDependencies) DumpApplication {
+	defaultDependencies := newDefaultDumpDependencies()
+
+	if dependencies.ReadArchive == nil {
+		dependencies.ReadArchive = defaultDependencies.ReadArchive
+	}
+	if dependencies.BuildResolver == nil {
+		dependencies.BuildResolver = defaultDependencies.BuildResolver
+	}
+	if dependencies.RenderComparison == nil {
+		dependencies.RenderComparison = defaultDependencies.RenderComparison
+	}
+	if dependencies.WriteOutputFile == nil {
+		dependencies.WriteOutputFile = defaultDependencies.WriteOutputFile
+	}
+	if dependencies.Stdout == nil {
+		dependencies.Stdout = defaultDependencies.Stdout
+	}
+	if dependencies.Stderr == nil {
+		dependencies.Stderr = defaultDependencies.Stderr
+	}
+
+	return DumpApplication{dependencies: dependencies}
+}
+
+func (application DumpApplication) Run(executionContext context.Context, configuration DumpConfiguration) error {
+	accountSetsOwnerA, ownerIdentityA, readArchiveError := application.dependencies.ReadArchive(configuration.ZipPathA)
+	if readArchiveError != nil {
+		return fmt.Errorf(loadErrorFormat, configuration.ZipPathA, readArchiveError)
+	}
+	accountSetsOwnerB, ownerIdentityB, readArchiveError := application.dependencies.ReadArchive(configuration.ZipPathB)
+	if readArchiveError != nil {
+		return fmt.Errorf(loadErrorFormat, configuration.ZipPathB, readArchiveError)
+	}
+
+	handleResolver, resolverError := application.dependencies.BuildResolver()
+	if resolverError != nil {
+		return fmt.Errorf(handlesResolverErrorFormat, resolverError)
+	}
+
+	resolutionErrors := matrix.MaybeResolveHandles(executionContext, handleResolver, true, &accountSetsOwnerA, &accountSetsOwnerB)
+	for accountID, resolutionError := range resolutionErrors {
+		fmt.Fprintf(application.dependencies.Stderr, handleResolutionErrorFormat, accountID, resolutionError)
+	}
+
+	comparison := matrix.BuildComparison(accountSetsOwnerA, accountSetsOwnerB, ownerIdentityA, ownerIdentityB)
+
+	pageHTML, renderError := application.dependencies.RenderComparison(matrix.ComparisonPageData{Comparison: &comparison})
+	if renderError != nil {
+		return fmt.Errorf(renderErrorFormat, renderError)
+	}
+
+	if writeError := application.dependencies.WriteOutputFile(configuration.OutputPath, pageHTML); writeError != nil {
+		return writeError
+	}
+
+	fmt.Fprintf(application.dependencies.Stdout, writeSuccessMessageFormat+"\n", configuration.OutputPath)
+	return nil
+}
+
+func newDefaultDumpDependencies() DumpDependencies {
+	return DumpDependencies{
+		ReadArchive: matrix.ReadTwitterZip,
+		BuildResolver: func() (matrix.AccountHandleResolver, error) {
+			return handles.NewResolver(handles.Config{})
+		},
+		RenderComparison: matrix.RenderComparisonPage,
+		WriteOutputFile:  defaultWriteOutputFile,
+		Stdout:           os.Stdout,
+		Stderr:           os.Stderr,
+	}
+}
+
+func defaultWriteOutputFile(outputPath string, contents string) error {
+	file, createError := os.Create(outputPath)
+	if createError != nil {
+		return fmt.Errorf(createFileErrorFormat, outputPath, createError)
+	}
+	defer file.Close()
+
+	if _, writeError := file.WriteString(contents); writeError != nil {
+		return fmt.Errorf(writeFileErrorFormat, outputPath, writeError)
+	}
+	return nil
+}

--- a/cmd/dump/main.go
+++ b/cmd/dump/main.go
@@ -5,9 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-
-	"github.com/f-sync/fsync/internal/handles"
-	"github.com/f-sync/fsync/internal/matrix"
 )
 
 const (
@@ -25,6 +22,7 @@ const (
 	createFileErrorFormat       = "create %s: %v"
 	writeFileErrorFormat        = "write %s: %v"
 	handlesResolverErrorFormat  = "handles resolver: %v"
+	writeSuccessMessageFormat   = "Wrote %s"
 )
 
 func main() {
@@ -42,42 +40,11 @@ func main() {
 		os.Exit(2)
 	}
 
-	accountSetsA, ownerA, err := matrix.ReadTwitterZip(zipPathA)
-	if err != nil {
-		dief(loadErrorFormat, zipPathA, err)
+	application := NewDumpApplication()
+	configuration := DumpConfiguration{ZipPathA: zipPathA, ZipPathB: zipPathB, OutputPath: outputPath}
+	if err := application.Run(context.Background(), configuration); err != nil {
+		dief("%v", err)
 	}
-	accountSetsB, ownerB, err := matrix.ReadTwitterZip(zipPathB)
-	if err != nil {
-		dief(loadErrorFormat, zipPathB, err)
-	}
-
-	resolver, err := handles.NewResolver(handles.Config{})
-	if err != nil {
-		dief(handlesResolverErrorFormat, err)
-	}
-	resolutionErrors := matrix.MaybeResolveHandles(context.Background(), resolver, true, &accountSetsA, &accountSetsB)
-	for accountID, resolutionErr := range resolutionErrors {
-		fmt.Fprintf(os.Stderr, handleResolutionErrorFormat, accountID, resolutionErr)
-	}
-
-	comparison := matrix.BuildComparison(accountSetsA, accountSetsB, ownerA, ownerB)
-
-	pageHTML, err := matrix.RenderComparisonPage(matrix.ComparisonPageData{Comparison: &comparison})
-	if err != nil {
-		dief(renderErrorFormat, err)
-	}
-
-	file, err := os.Create(outputPath)
-	if err != nil {
-		dief(createFileErrorFormat, outputPath, err)
-	}
-	defer file.Close()
-
-	if _, err := file.WriteString(pageHTML); err != nil {
-		dief(writeFileErrorFormat, outputPath, err)
-	}
-
-	fmt.Println("Wrote", outputPath)
 }
 
 func dief(format string, args ...any) {

--- a/cmd/dump/main_test.go
+++ b/cmd/dump/main_test.go
@@ -1,0 +1,175 @@
+package main_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	dump "github.com/f-sync/fsync/cmd/dump"
+	"github.com/f-sync/fsync/internal/handles"
+	"github.com/f-sync/fsync/internal/matrix"
+)
+
+const (
+	testZipPathA                  = "zip-a-path"
+	testZipPathB                  = "zip-b-path"
+	testOutputPath                = "output.html"
+	testAccountID                 = "555123"
+	testResolvedUserName          = "resolved_user"
+	testResolvedDisplayName       = "Resolved User"
+	testRenderedHTMLDocument      = "<html>ok</html>"
+	handleResolutionWarningFormat = "warning: handle lookup for %s failed: %s\n"
+	testResolutionErrorMessage    = "fetch failed"
+)
+
+type resolverStub struct {
+	callCount   int
+	expectedIDs []string
+	resultsByID map[string]handles.Result
+}
+
+func (resolver *resolverStub) ResolveMany(_ context.Context, accountIDs []string) map[string]handles.Result {
+	resolver.callCount++
+	resolver.expectedIDs = append(resolver.expectedIDs, accountIDs...)
+	return resolver.resultsByID
+}
+
+type comparisonRendererStub struct {
+	callCount int
+	lastData  matrix.ComparisonPageData
+}
+
+func (renderer *comparisonRendererStub) Render(pageData matrix.ComparisonPageData) (string, error) {
+	renderer.callCount++
+	renderer.lastData = pageData
+	return testRenderedHTMLDocument, nil
+}
+
+type outputWriterStub struct {
+	calls []outputWriteCall
+}
+
+type outputWriteCall struct {
+	path     string
+	contents string
+}
+
+func (writer *outputWriterStub) Write(path string, contents string) error {
+	writer.calls = append(writer.calls, outputWriteCall{path: path, contents: contents})
+	return nil
+}
+
+func TestDumpApplicationResolvesHandlesByDefault(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                string
+		resolverResults     map[string]handles.Result
+		expectedWarning     string
+		expectedUserName    string
+		expectedDisplayName string
+	}{
+		{
+			name: "successful resolution",
+			resolverResults: map[string]handles.Result{
+				testAccountID: {
+					Record: handles.AccountRecord{AccountID: testAccountID, UserName: testResolvedUserName, DisplayName: testResolvedDisplayName},
+				},
+			},
+			expectedUserName:    testResolvedUserName,
+			expectedDisplayName: testResolvedDisplayName,
+		},
+		{
+			name: "resolution failure emits warning",
+			resolverResults: map[string]handles.Result{
+				testAccountID: {
+					Record: handles.AccountRecord{AccountID: testAccountID},
+					Err:    errors.New(testResolutionErrorMessage),
+				},
+			},
+			expectedWarning: fmt.Sprintf(handleResolutionWarningFormat, testAccountID, testResolutionErrorMessage),
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			archiveLoader := func(string) (matrix.AccountSets, matrix.OwnerIdentity, error) {
+				accountRecord := matrix.AccountRecord{AccountID: testAccountID}
+				accountSets := matrix.AccountSets{
+					Followers: map[string]matrix.AccountRecord{testAccountID: accountRecord},
+					Following: map[string]matrix.AccountRecord{testAccountID: accountRecord},
+				}
+				ownerIdentity := matrix.OwnerIdentity{AccountID: testAccountID}
+				return accountSets, ownerIdentity, nil
+			}
+
+			resolver := &resolverStub{resultsByID: testCase.resolverResults}
+			renderer := &comparisonRendererStub{}
+			writer := &outputWriterStub{}
+			stdoutBuffer := &bytes.Buffer{}
+			stderrBuffer := &bytes.Buffer{}
+
+			dependencies := dump.DumpDependencies{
+				ReadArchive:      archiveLoader,
+				BuildResolver:    func() (matrix.AccountHandleResolver, error) { return resolver, nil },
+				RenderComparison: renderer.Render,
+				WriteOutputFile:  writer.Write,
+				Stdout:           stdoutBuffer,
+				Stderr:           stderrBuffer,
+			}
+
+			application := dump.NewDumpApplicationWithDependencies(dependencies)
+			configuration := dump.DumpConfiguration{ZipPathA: testZipPathA, ZipPathB: testZipPathB, OutputPath: testOutputPath}
+
+			if runError := application.Run(context.Background(), configuration); runError != nil {
+				t.Fatalf("unexpected run error: %v", runError)
+			}
+
+			if resolver.callCount != 1 {
+				t.Fatalf("expected resolver to be invoked once, got %d", resolver.callCount)
+			}
+			if len(resolver.expectedIDs) == 0 || resolver.expectedIDs[0] != testAccountID {
+				t.Fatalf("expected resolver to receive account id %s, got %v", testAccountID, resolver.expectedIDs)
+			}
+
+			if renderer.callCount != 1 {
+				t.Fatalf("expected renderer to be invoked once, got %d", renderer.callCount)
+			}
+			if renderer.lastData.Comparison == nil {
+				t.Fatalf("expected comparison data to be provided")
+			}
+
+			accountRecord := renderer.lastData.Comparison.AccountSetsA.Followers[testAccountID]
+			if accountRecord.UserName != testCase.expectedUserName {
+				t.Fatalf("unexpected username enrichment: %q", accountRecord.UserName)
+			}
+			if accountRecord.DisplayName != testCase.expectedDisplayName {
+				t.Fatalf("unexpected display name enrichment: %q", accountRecord.DisplayName)
+			}
+
+			if len(writer.calls) != 1 {
+				t.Fatalf("expected output writer to be invoked once, got %d", len(writer.calls))
+			}
+			if writer.calls[0].path != testOutputPath {
+				t.Fatalf("unexpected output path: %s", writer.calls[0].path)
+			}
+			if writer.calls[0].contents != testRenderedHTMLDocument {
+				t.Fatalf("unexpected rendered contents: %s", writer.calls[0].contents)
+			}
+
+			expectedStdout := fmt.Sprintf("Wrote %s\n", testOutputPath)
+			if stdoutBuffer.String() != expectedStdout {
+				t.Fatalf("unexpected stdout: %q", stdoutBuffer.String())
+			}
+
+			if stderrBuffer.String() != testCase.expectedWarning {
+				t.Fatalf("unexpected stderr: %q", stderrBuffer.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- refactor the dump CLI into a testable application that always builds a resolver before rendering
- add integration-style tests to verify handle enrichment and warning emission when resolution fails
- update documentation to describe the mandatory Chrome/network prerequisites for the built-in resolver

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cc94c475488327a3699ad4c7030f9a