### PR TITLE
Ensure matrices hide numeric identifiers

### DIFF
--- a/internal/matrix/assets.go
+++ b/internal/matrix/assets.go
@@ -6,7 +6,6 @@ import (
 	"html/template"
 	"io/fs"
 	"sort"
-	"strings"
 )
 
 //go:embed web/static/* web/templates/*
@@ -19,7 +18,6 @@ const (
 	embeddedBaseCSSPath    = "web/static/base.css"
 	embeddedAppJSPath      = "web/static/app.js"
 	twitterUserNameBaseURL = "https://twitter.com/"
-	twitterUserIDBaseURL   = "https://twitter.com/i/user/"
 	accountHandlePrefix    = "@"
 	displayHandleFormat    = "%s (%s%s)"
 	pageTitleText          = "Twitter Relationship Matrix"
@@ -46,20 +44,7 @@ func parseTemplates(fileSystem fs.FS, files ...string) (*template.Template, erro
 			return newAccountPresentation(record).ProfileURL()
 		},
 		"label": func(record AccountRecord) string {
-			display := strings.TrimSpace(record.DisplayName)
-			handle := strings.TrimSpace(record.UserName)
-			switch {
-			case display != "" && handle != "":
-				return fmt.Sprintf(displayHandleFormat, display, accountHandlePrefix, handle)
-			case display != "":
-				return display
-			case handle != "":
-				return accountHandlePrefix + handle
-			case record.AccountID != "":
-				return record.AccountID
-			default:
-				return unknownLabelText
-			}
+			return resolveIdentityLabel(record.DisplayName, record.UserName)
 		},
 		"has": func(flags map[string]bool, accountID string) bool { return flags[accountID] },
 	})
@@ -80,18 +65,5 @@ func mapKeys(flags map[string]bool) []string {
 }
 
 func ownerPretty(identity OwnerIdentity) string {
-	display := strings.TrimSpace(identity.DisplayName)
-	handle := strings.TrimSpace(identity.UserName)
-	switch {
-	case display != "" && handle != "":
-		return fmt.Sprintf(displayHandleFormat, display, accountHandlePrefix, handle)
-	case display != "":
-		return display
-	case handle != "":
-		return accountHandlePrefix + handle
-	case identity.AccountID != "":
-		return identity.AccountID
-	default:
-		return unknownLabelText
-	}
+	return resolveIdentityLabel(identity.DisplayName, identity.UserName)
 }

--- a/internal/matrix/presentation.go
+++ b/internal/matrix/presentation.go
@@ -1,0 +1,33 @@
+package matrix
+
+import (
+	"fmt"
+	"strings"
+)
+
+// resolveIdentityLabel returns a display label constructed from the provided display name and handle.
+// The label includes both the display name and handle when available and falls back to the handle or
+// a placeholder when necessary.
+func resolveIdentityLabel(displayName string, userName string) string {
+	trimmedDisplayName := strings.TrimSpace(displayName)
+	trimmedUserName := strings.TrimSpace(userName)
+	switch {
+	case trimmedDisplayName != "" && trimmedUserName != "":
+		return fmt.Sprintf(displayHandleFormat, trimmedDisplayName, accountHandlePrefix, trimmedUserName)
+	case trimmedDisplayName != "":
+		return trimmedDisplayName
+	case trimmedUserName != "":
+		return accountHandlePrefix + trimmedUserName
+	default:
+		return unknownLabelText
+	}
+}
+
+// resolveHandleLabel formats a handle with the appropriate prefix when the handle is present.
+func resolveHandleLabel(userName string) string {
+	trimmedUserName := strings.TrimSpace(userName)
+	if trimmedUserName == "" {
+		return ""
+	}
+	return accountHandlePrefix + trimmedUserName
+}

--- a/internal/matrix/render.go
+++ b/internal/matrix/render.go
@@ -97,33 +97,19 @@ func newAccountPresentation(record AccountRecord) accountPresentation {
 }
 
 func (presentation accountPresentation) Display() string {
-	display := strings.TrimSpace(presentation.record.DisplayName)
-	if display != "" {
-		return display
-	}
-	handle := strings.TrimSpace(presentation.record.UserName)
-	if handle != "" {
-		return accountHandlePrefix + handle
-	}
-	if presentation.record.AccountID != "" {
-		return presentation.record.AccountID
-	}
-	return unknownLabelText
+	return resolveIdentityLabel(presentation.record.DisplayName, presentation.record.UserName)
 }
 
 func (presentation accountPresentation) Handle() string {
-	handle := strings.TrimSpace(presentation.record.UserName)
-	if handle == "" {
-		return ""
-	}
-	return accountHandlePrefix + handle
+	return resolveHandleLabel(presentation.record.UserName)
 }
 
 func (presentation accountPresentation) ProfileURL() string {
-	if strings.TrimSpace(presentation.record.UserName) != "" {
-		return twitterUserNameBaseURL + presentation.record.UserName
+	trimmedHandle := strings.TrimSpace(presentation.record.UserName)
+	if trimmedHandle == "" {
+		return ""
 	}
-	return twitterUserIDBaseURL + presentation.record.AccountID
+	return twitterUserNameBaseURL + trimmedHandle
 }
 
 type accountBadgeDecorator struct {

--- a/internal/matrix/render_test.go
+++ b/internal/matrix/render_test.go
@@ -73,3 +73,85 @@ func TestRenderComparisonPageWithComparisonData(t *testing.T) {
 		}
 	}
 }
+
+func TestRenderComparisonPageOmitsNumericIdentifiersWhenMetadataMissing(t *testing.T) {
+	const (
+		placeholderText      = "Unknown"
+		ownerAccountIDAlpha  = "9001"
+		ownerAccountIDBeta   = "9002"
+		followerAccountID    = "987654321"
+		idLinkPrefixFragment = "https://twitter.com/i/user/"
+	)
+
+	testCases := []struct {
+		name                string
+		ownerA              matrix.OwnerIdentity
+		ownerB              matrix.OwnerIdentity
+		followerRecord      matrix.AccountRecord
+		expectedPlaceholder string
+		forbiddenIdentifier string
+		forbiddenOwnerAID   string
+		forbiddenOwnerBID   string
+	}{
+		{
+			name:                "only account identifiers provided",
+			ownerA:              matrix.OwnerIdentity{AccountID: ownerAccountIDAlpha},
+			ownerB:              matrix.OwnerIdentity{AccountID: ownerAccountIDBeta},
+			followerRecord:      matrix.AccountRecord{AccountID: followerAccountID},
+			expectedPlaceholder: placeholderText,
+			forbiddenIdentifier: followerAccountID,
+			forbiddenOwnerAID:   ownerAccountIDAlpha,
+			forbiddenOwnerBID:   ownerAccountIDBeta,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			comparison := matrix.ComparisonResult{
+				AccountSetsA: matrix.AccountSets{
+					Followers: map[string]matrix.AccountRecord{testCase.followerRecord.AccountID: testCase.followerRecord},
+					Following: map[string]matrix.AccountRecord{testCase.followerRecord.AccountID: testCase.followerRecord},
+					Muted:     map[string]bool{},
+					Blocked:   map[string]bool{},
+				},
+				AccountSetsB: matrix.AccountSets{
+					Followers: map[string]matrix.AccountRecord{},
+					Following: map[string]matrix.AccountRecord{},
+					Muted:     map[string]bool{},
+					Blocked:   map[string]bool{},
+				},
+				OwnerA:             testCase.ownerA,
+				OwnerB:             testCase.ownerB,
+				OwnerAFriends:      []matrix.AccountRecord{testCase.followerRecord},
+				OwnerAFollowersAll: []matrix.AccountRecord{testCase.followerRecord},
+			}
+
+			pageData := matrix.ComparisonPageData{Comparison: &comparison}
+			html, err := matrix.RenderComparisonPage(pageData)
+			if err != nil {
+				t.Fatalf("RenderComparisonPage returned error: %v", err)
+			}
+
+			if !strings.Contains(html, testCase.expectedPlaceholder) {
+				t.Fatalf("expected HTML to contain placeholder %q", testCase.expectedPlaceholder)
+			}
+
+			if strings.Contains(html, ">"+testCase.forbiddenIdentifier+"<") {
+				t.Fatalf("expected account identifier %q to be hidden in rendered HTML", testCase.forbiddenIdentifier)
+			}
+
+			if strings.Contains(html, ">"+testCase.forbiddenOwnerAID+"<") {
+				t.Fatalf("expected owner A identifier %q to be hidden in rendered HTML", testCase.forbiddenOwnerAID)
+			}
+
+			if strings.Contains(html, ">"+testCase.forbiddenOwnerBID+"<") {
+				t.Fatalf("expected owner B identifier %q to be hidden in rendered HTML", testCase.forbiddenOwnerBID)
+			}
+
+			if strings.Contains(html, idLinkPrefixFragment) {
+				t.Fatalf("expected HTML to avoid ID-based profile links containing %q", idLinkPrefixFragment)
+			}
+		})
+	}
+}

--- a/internal/matrix/web/templates/index.tmpl
+++ b/internal/matrix/web/templates/index.tmpl
@@ -284,9 +284,14 @@
     {{ $entry := . }}
     <li class="mb-3 pb-3 border-bottom">
         <div class="d-flex flex-column">
-            <a class="text-decoration-none" target="_blank" rel="noopener" href="{{ $entry.Presentation.ProfileURL }}">
+            {{ $profileURL := $entry.Presentation.ProfileURL }}
+            {{ if $profileURL }}
+                <a class="text-decoration-none" target="_blank" rel="noopener" href="{{ $profileURL }}">
+                    <strong class="d-block">{{ $entry.Presentation.Display }}</strong>
+                </a>
+            {{ else }}
                 <strong class="d-block">{{ $entry.Presentation.Display }}</strong>
-            </a>
+            {{ end }}
             {{ with $handle := $entry.Presentation.Handle }}
                 <span class="text-muted small">{{ $handle }}</span>
             {{ end }}

--- a/tests/frontend_render_test.go
+++ b/tests/frontend_render_test.go
@@ -1,0 +1,156 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	frontendAppScriptRelativePath      = "../internal/matrix/web/static/app.js"
+	frontendClosureSuffix              = "})();"
+	frontendInstrumentedHookName       = "__fsyncRenderAccountRecord"
+	frontendInstrumentedScriptFileName = "app_instrumented.js"
+	frontendDriverScriptFileName       = "driver.js"
+	frontendPlaceholderText            = "Unknown"
+	frontendIDLinkFragment             = "/i/user/"
+	frontendNodeCommand                = "node"
+)
+
+const frontendNodeDriverTemplate = `const vm = require("vm");
+const fs = require("fs");
+
+const scriptPath = process.argv[2];
+const payloadJSON = process.argv[3];
+const scriptContent = fs.readFileSync(scriptPath, "utf8");
+
+function createStubElement() {
+    return {
+        className: "",
+        textContent: "",
+        innerHTML: "",
+        dataset: {},
+        classList: {
+            add() {},
+            remove() {},
+            toggle() {},
+        },
+        appendChild() {},
+        setAttribute() {},
+        addEventListener() {},
+        getAttribute() { return ""; },
+    };
+}
+
+const sandbox = {
+    console,
+    document: {
+        getElementById() { return null; },
+        querySelectorAll() { return []; },
+        createElement() { return createStubElement(); },
+    },
+    window: { location: { reload() {} } },
+    setTimeout,
+    clearTimeout,
+};
+
+vm.createContext(sandbox);
+new vm.Script(scriptContent, { filename: scriptPath }).runInContext(sandbox);
+
+const renderAccountRecordHook = sandbox.%s;
+if (typeof renderAccountRecordHook !== "function") {
+    throw new Error("renderAccountRecord hook missing");
+}
+
+const payload = JSON.parse(payloadJSON);
+const html = renderAccountRecordHook(payload.record, payload.metaSources, payload.includeFollowAction);
+process.stdout.write(html);
+`
+
+func TestFrontEndRenderAccountRecordOmitsNumericIdentifier(t *testing.T) {
+	appScriptBytes, readErr := os.ReadFile(frontendAppScriptRelativePath)
+	if readErr != nil {
+		t.Fatalf("read app.js: %v", readErr)
+	}
+	scriptText := string(appScriptBytes)
+	closureIndex := strings.LastIndex(scriptText, frontendClosureSuffix)
+	if closureIndex == -1 {
+		t.Fatalf("unable to locate closure suffix %q in app.js", frontendClosureSuffix)
+	}
+	instrumentedScriptText := scriptText[:closureIndex] + fmt.Sprintf("    globalThis.%s = renderAccountRecord;\n", frontendInstrumentedHookName) + frontendClosureSuffix
+
+	temporaryDirectory := t.TempDir()
+	instrumentedScriptPath := filepath.Join(temporaryDirectory, frontendInstrumentedScriptFileName)
+	if writeErr := os.WriteFile(instrumentedScriptPath, []byte(instrumentedScriptText), 0o600); writeErr != nil {
+		t.Fatalf("write instrumented script: %v", writeErr)
+	}
+
+	driverScriptPath := filepath.Join(temporaryDirectory, frontendDriverScriptFileName)
+	driverScriptText := fmt.Sprintf(frontendNodeDriverTemplate, frontendInstrumentedHookName)
+	if writeErr := os.WriteFile(driverScriptPath, []byte(driverScriptText), 0o600); writeErr != nil {
+		t.Fatalf("write driver script: %v", writeErr)
+	}
+
+	testCases := []struct {
+		name                string
+		record              map[string]string
+		includeFollowAction bool
+	}{
+		{
+			name:                "only numeric identifier present",
+			record:              map[string]string{"AccountID": "13579"},
+			includeFollowAction: false,
+		},
+		{
+			name:                "numeric identifier with follow action requested",
+			record:              map[string]string{"AccountID": "24680"},
+			includeFollowAction: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			payload := struct {
+				Record              map[string]string `json:"record"`
+				MetaSources         []map[string]any  `json:"metaSources"`
+				IncludeFollowAction bool              `json:"includeFollowAction"`
+			}{
+				Record:              testCase.record,
+				MetaSources:         []map[string]any{},
+				IncludeFollowAction: testCase.includeFollowAction,
+			}
+
+			payloadBytes, marshalErr := json.Marshal(payload)
+			if marshalErr != nil {
+				t.Fatalf("marshal payload: %v", marshalErr)
+			}
+
+			command := exec.Command(frontendNodeCommand, driverScriptPath, instrumentedScriptPath, string(payloadBytes))
+			var stderrBuffer bytes.Buffer
+			command.Stderr = &stderrBuffer
+			outputBytes, runErr := command.Output()
+			if runErr != nil {
+				t.Fatalf("execute node driver: %v\n%s", runErr, stderrBuffer.String())
+			}
+
+			htmlOutput := string(outputBytes)
+			if strings.Contains(htmlOutput, testCase.record["AccountID"]) {
+				t.Fatalf("expected rendered HTML to omit numeric identifier %q, got %q", testCase.record["AccountID"], htmlOutput)
+			}
+
+			if !strings.Contains(htmlOutput, frontendPlaceholderText) {
+				t.Fatalf("expected rendered HTML to include placeholder %q, got %q", frontendPlaceholderText, htmlOutput)
+			}
+
+			if strings.Contains(htmlOutput, frontendIDLinkFragment) {
+				t.Fatalf("expected rendered HTML to avoid ID-based profile links containing %q, got %q", frontendIDLinkFragment, htmlOutput)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add helpers that resolve identity labels and handles so templates and presenters always return names or the Unknown placeholder instead of numeric IDs【F:internal/matrix/presentation.go†L1-L33】【F:internal/matrix/assets.go†L41-L68】【F:internal/matrix/render.go†L96-L113】
- update the HTML template and client renderer to skip ID-based profile links, reuse the placeholder text, and keep follow actions handle-only【F:internal/matrix/web/templates/index.tmpl†L283-L306】【F:internal/matrix/web/static/app.js†L442-L475】
- expand server- and browser-side tests to confirm that ID-only records render the placeholder and never emit ID links【F:internal/matrix/render_test.go†L70-L157】【F:tests/frontend_render_test.go†L1-L156】

## Testing
- go test ./...【03fb43†L1-L7】

------
https://chatgpt.com/codex/tasks/task_e_68ccb795aaa88327bbbad557a898b0ec