### PR TITLE
Resolve blocked handle metadata

### DIFF
--- a/internal/matrix/comparison_test.go
+++ b/internal/matrix/comparison_test.go
@@ -90,6 +90,104 @@ func TestBuildComparison(t *testing.T) {
 	}
 }
 
+func TestBuildComparisonUsesBlockedRecords(t *testing.T) {
+	resolvedRecordA := matrix.AccountRecord{AccountID: "100", UserName: "blocked_a", DisplayName: "Blocked A"}
+	resolvedRecordB := matrix.AccountRecord{AccountID: "200", UserName: "blocked_b", DisplayName: "Blocked B"}
+	sharedResolvedRecord := matrix.AccountRecord{AccountID: "300", UserName: "shared_blocked", DisplayName: "Shared Blocked"}
+
+	accountSetsA := matrix.AccountSets{
+		Blocked: map[string]bool{
+			resolvedRecordA.AccountID:      true,
+			sharedResolvedRecord.AccountID: true,
+		},
+		BlockedRecords: map[string]matrix.AccountRecord{
+			resolvedRecordA.AccountID: resolvedRecordA,
+		},
+	}
+	accountSetsB := matrix.AccountSets{
+		Blocked: map[string]bool{
+			resolvedRecordB.AccountID:      true,
+			sharedResolvedRecord.AccountID: true,
+		},
+		BlockedRecords: map[string]matrix.AccountRecord{
+			resolvedRecordB.AccountID:      resolvedRecordB,
+			sharedResolvedRecord.AccountID: sharedResolvedRecord,
+		},
+	}
+
+	comparison := matrix.BuildComparison(accountSetsA, accountSetsB, matrix.OwnerIdentity{}, matrix.OwnerIdentity{})
+
+	findRecord := func(records []matrix.AccountRecord, accountID string) (matrix.AccountRecord, bool) {
+		for _, record := range records {
+			if record.AccountID == accountID {
+				return record, true
+			}
+		}
+		return matrix.AccountRecord{}, false
+	}
+
+	testCases := []struct {
+		name                string
+		accountID           string
+		expectedDisplayName string
+		expectedUserName    string
+		recordsSelector     func(matrix.ComparisonResult) []matrix.AccountRecord
+	}{
+		{
+			name:                "owner a uses local blocked record",
+			accountID:           resolvedRecordA.AccountID,
+			expectedDisplayName: resolvedRecordA.DisplayName,
+			expectedUserName:    resolvedRecordA.UserName,
+			recordsSelector: func(result matrix.ComparisonResult) []matrix.AccountRecord {
+				return result.OwnerABlockedAll
+			},
+		},
+		{
+			name:                "owner a reuses other owner's blocked metadata",
+			accountID:           sharedResolvedRecord.AccountID,
+			expectedDisplayName: sharedResolvedRecord.DisplayName,
+			expectedUserName:    sharedResolvedRecord.UserName,
+			recordsSelector: func(result matrix.ComparisonResult) []matrix.AccountRecord {
+				return result.OwnerABlockedAll
+			},
+		},
+		{
+			name:                "owner b uses local blocked record",
+			accountID:           resolvedRecordB.AccountID,
+			expectedDisplayName: resolvedRecordB.DisplayName,
+			expectedUserName:    resolvedRecordB.UserName,
+			recordsSelector: func(result matrix.ComparisonResult) []matrix.AccountRecord {
+				return result.OwnerBBlockedAll
+			},
+		},
+		{
+			name:                "owner b preserves shared blocked metadata",
+			accountID:           sharedResolvedRecord.AccountID,
+			expectedDisplayName: sharedResolvedRecord.DisplayName,
+			expectedUserName:    sharedResolvedRecord.UserName,
+			recordsSelector: func(result matrix.ComparisonResult) []matrix.AccountRecord {
+				return result.OwnerBBlockedAll
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			record, found := findRecord(testCase.recordsSelector(comparison), testCase.accountID)
+			if !found {
+				t.Fatalf("expected blocked record for %s", testCase.accountID)
+			}
+			if record.DisplayName != testCase.expectedDisplayName {
+				t.Fatalf("unexpected display name: %s", record.DisplayName)
+			}
+			if record.UserName != testCase.expectedUserName {
+				t.Fatalf("unexpected username: %s", record.UserName)
+			}
+		})
+	}
+}
+
 func assertIDsEqual(t *testing.T, label string, records []matrix.AccountRecord, expectedIDs []string) {
 	t.Helper()
 	if len(records) != len(expectedIDs) {

--- a/internal/matrix/loader.go
+++ b/internal/matrix/loader.go
@@ -121,10 +121,12 @@ func ReadTwitterZip(zipPath string) (AccountSets, OwnerIdentity, error) {
 	loadIfNeeded(dataTypeBlock)
 
 	accountSets := AccountSets{
-		Followers: map[string]AccountRecord{},
-		Following: map[string]AccountRecord{},
-		Muted:     map[string]bool{},
-		Blocked:   map[string]bool{},
+		Followers:      map[string]AccountRecord{},
+		Following:      map[string]AccountRecord{},
+		Muted:          map[string]bool{},
+		Blocked:        map[string]bool{},
+		MutedRecords:   map[string]AccountRecord{},
+		BlockedRecords: map[string]AccountRecord{},
 	}
 
 	if data := blobs[followingFileName]; len(data) > 0 {

--- a/internal/matrix/models.go
+++ b/internal/matrix/models.go
@@ -6,11 +6,14 @@ import "github.com/f-sync/fsync/internal/handles"
 type AccountRecord = handles.AccountRecord
 
 // AccountSets contains the relationship data discovered for a single owner.
+// MutedRecords and BlockedRecords hold any resolved profile metadata for muted and blocked identifiers.
 type AccountSets struct {
-	Followers map[string]AccountRecord
-	Following map[string]AccountRecord
-	Muted     map[string]bool
-	Blocked   map[string]bool
+	Followers      map[string]AccountRecord
+	Following      map[string]AccountRecord
+	Muted          map[string]bool
+	Blocked        map[string]bool
+	MutedRecords   map[string]AccountRecord
+	BlockedRecords map[string]AccountRecord
 }
 
 // OwnerIdentity describes the owner of a Twitter export archive.

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -438,10 +438,12 @@ func ownerSummary(owner matrix.OwnerIdentity) string {
 
 func copyAccountSets(source matrix.AccountSets) matrix.AccountSets {
 	return matrix.AccountSets{
-		Followers: copyAccountRecordMap(source.Followers),
-		Following: copyAccountRecordMap(source.Following),
-		Muted:     copyBoolMap(source.Muted),
-		Blocked:   copyBoolMap(source.Blocked),
+		Followers:      copyAccountRecordMap(source.Followers),
+		Following:      copyAccountRecordMap(source.Following),
+		Muted:          copyBoolMap(source.Muted),
+		Blocked:        copyBoolMap(source.Blocked),
+		MutedRecords:   copyAccountRecordMap(source.MutedRecords),
+		BlockedRecords: copyAccountRecordMap(source.BlockedRecords),
 	}
 }
 


### PR DESCRIPTION
## Summary
- enrich account sets with resolved data for blocked and muted identifiers and persist it through the comparison store
- ensure comparison builders reuse resolved blocked records across owners
- add router and matrix tests covering blocked-only handle resolution behavior

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ccbb5a94f0832798c905ba54512fba