### PR TITLE
Add asynchronous comparison task progress tracking

### DIFF
--- a/internal/matrix/handles.go
+++ b/internal/matrix/handles.go
@@ -3,6 +3,7 @@ package matrix
 import (
 	"context"
 	"errors"
+	"sort"
 
 	"github.com/f-sync/fsync/internal/handles"
 )
@@ -21,37 +22,72 @@ type accountResolutionTarget struct {
 	records map[string]AccountRecord
 }
 
+// HandleResolutionPlan captures the set of account identifiers requiring handle resolution.
+type HandleResolutionPlan struct {
+	targets map[string][]accountResolutionTarget
+	order   []string
+}
+
+// NewHandleResolutionPlan builds a plan to update account records after handle resolution completes.
+func NewHandleResolutionPlan(accountSets ...*AccountSets) HandleResolutionPlan {
+	plan := HandleResolutionPlan{targets: make(map[string][]accountResolutionTarget)}
+	for _, accountSet := range accountSets {
+		if accountSet == nil {
+			continue
+		}
+		plan.addRecordTargets(accountSet.Followers)
+		plan.addRecordTargets(accountSet.Following)
+		if len(accountSet.Muted) > 0 {
+			ensureAccountRecordMap(&accountSet.MutedRecords)
+			plan.addFlagTargets(accountSet.Muted, accountSet.MutedRecords)
+		}
+		if len(accountSet.Blocked) > 0 {
+			ensureAccountRecordMap(&accountSet.BlockedRecords)
+			plan.addFlagTargets(accountSet.Blocked, accountSet.BlockedRecords)
+		}
+	}
+	return plan
+}
+
+// TargetCount reports the number of unique account identifiers requiring resolution.
+func (plan HandleResolutionPlan) TargetCount() int {
+	return len(plan.order)
+}
+
+// AccountIDs returns the ordered list of account identifiers to resolve.
+func (plan HandleResolutionPlan) AccountIDs() []string {
+	ordered := make([]string, len(plan.order))
+	copy(ordered, plan.order)
+	return ordered
+}
+
+// ApplyResolvedRecord stores the resolved handle information for all targets associated with accountID.
+func (plan HandleResolutionPlan) ApplyResolvedRecord(accountID string, resolved handles.AccountRecord) {
+	targets, exists := plan.targets[accountID]
+	if !exists {
+		return
+	}
+	for _, target := range targets {
+		record := target.records[accountID]
+		record.AccountID = accountID
+		record.UserName = resolved.UserName
+		record.DisplayName = resolved.DisplayName
+		target.records[accountID] = record
+	}
+}
+
 // ResolveHandles enriches account sets with resolved handles whenever a resolver is provided.
 func ResolveHandles(ctx context.Context, resolver AccountHandleResolver, accountSets ...*AccountSets) map[string]error {
 	if resolver == nil {
 		return nil
 	}
 
-	accountIDTargets := make(map[string][]accountResolutionTarget)
-	for _, accountSet := range accountSets {
-		if accountSet == nil {
-			continue
-		}
-		collectRecordResolutionTargets(accountSet.Followers, accountIDTargets)
-		collectRecordResolutionTargets(accountSet.Following, accountIDTargets)
-		if len(accountSet.Muted) > 0 {
-			ensureAccountRecordMap(&accountSet.MutedRecords)
-			collectFlagResolutionTargets(accountSet.Muted, accountSet.MutedRecords, accountIDTargets)
-		}
-		if len(accountSet.Blocked) > 0 {
-			ensureAccountRecordMap(&accountSet.BlockedRecords)
-			collectFlagResolutionTargets(accountSet.Blocked, accountSet.BlockedRecords, accountIDTargets)
-		}
-	}
-	if len(accountIDTargets) == 0 {
+	plan := NewHandleResolutionPlan(accountSets...)
+	if plan.TargetCount() == 0 {
 		return nil
 	}
 
-	accountIDs := make([]string, 0, len(accountIDTargets))
-	for accountID := range accountIDTargets {
-		accountIDs = append(accountIDs, accountID)
-	}
-
+	accountIDs := plan.AccountIDs()
 	resolutionResults := resolver.ResolveMany(ctx, accountIDs)
 	errorsByAccountID := make(map[string]error)
 	for _, accountID := range accountIDs {
@@ -64,12 +100,7 @@ func ResolveHandles(ctx context.Context, resolver AccountHandleResolver, account
 			errorsByAccountID[accountID] = result.Err
 			continue
 		}
-		for _, target := range accountIDTargets[accountID] {
-			record := target.records[accountID]
-			record.UserName = result.Record.UserName
-			record.DisplayName = result.Record.DisplayName
-			target.records[accountID] = record
-		}
+		plan.ApplyResolvedRecord(accountID, result.Record)
 	}
 	if len(errorsByAccountID) == 0 {
 		return nil
@@ -77,14 +108,36 @@ func ResolveHandles(ctx context.Context, resolver AccountHandleResolver, account
 	return errorsByAccountID
 }
 
-func collectRecordResolutionTargets(source map[string]AccountRecord, targets map[string][]accountResolutionTarget) {
-	for accountID := range source {
-		targets[accountID] = append(targets[accountID], accountResolutionTarget{records: source})
+func ensureAccountRecordMap(records *map[string]AccountRecord) {
+	if *records == nil {
+		*records = map[string]AccountRecord{}
 	}
 }
 
-func collectFlagResolutionTargets(flags map[string]bool, records map[string]AccountRecord, targets map[string][]accountResolutionTarget) {
+func (plan *HandleResolutionPlan) addRecordTargets(source map[string]AccountRecord) {
+	if len(source) == 0 {
+		return
+	}
+	accountIDs := make([]string, 0, len(source))
+	for accountID := range source {
+		accountIDs = append(accountIDs, accountID)
+	}
+	sort.Strings(accountIDs)
+	for _, accountID := range accountIDs {
+		plan.appendTarget(accountID, accountResolutionTarget{records: source})
+	}
+}
+
+func (plan *HandleResolutionPlan) addFlagTargets(flags map[string]bool, records map[string]AccountRecord) {
+	if len(flags) == 0 {
+		return
+	}
+	accountIDs := make([]string, 0, len(flags))
 	for accountID := range flags {
+		accountIDs = append(accountIDs, accountID)
+	}
+	sort.Strings(accountIDs)
+	for _, accountID := range accountIDs {
 		record, exists := records[accountID]
 		if !exists {
 			records[accountID] = AccountRecord{AccountID: accountID}
@@ -92,12 +145,17 @@ func collectFlagResolutionTargets(flags map[string]bool, records map[string]Acco
 			record.AccountID = accountID
 			records[accountID] = record
 		}
-		targets[accountID] = append(targets[accountID], accountResolutionTarget{records: records})
+		plan.appendTarget(accountID, accountResolutionTarget{records: records})
 	}
 }
 
-func ensureAccountRecordMap(records *map[string]AccountRecord) {
-	if *records == nil {
-		*records = map[string]AccountRecord{}
+func (plan *HandleResolutionPlan) appendTarget(accountID string, target accountResolutionTarget) {
+	if plan.targets == nil {
+		plan.targets = make(map[string][]accountResolutionTarget)
 	}
+	if _, exists := plan.targets[accountID]; !exists {
+		plan.targets[accountID] = []accountResolutionTarget{}
+		plan.order = append(plan.order, accountID)
+	}
+	plan.targets[accountID] = append(plan.targets[accountID], target)
 }

--- a/internal/matrix/web/static/app.js
+++ b/internal/matrix/web/static/app.js
@@ -14,13 +14,24 @@
     const ID_COMPARISON_OPERATION = "cmpOp";
     const ID_COMPARISON_OUTPUT = "cmpOut";
     const ID_COMPARISON_BUTTON = "runCmp";
+    const ID_COMPARISON_PROGRESS = "comparisonProgress";
+    const ID_COMPARISON_PROGRESS_BAR = "comparisonProgressBar";
+    const ID_COMPARISON_PROGRESS_TEXT = "comparisonProgressText";
 
     const ROUTE_UPLOADS = "/api/uploads";
+    const ROUTE_COMPARE = "/api/compare";
+    const ROUTE_COMPARE_PROGRESS = "/api/compare/";
     const HTTP_METHOD_POST = "POST";
     const HTTP_METHOD_DELETE = "DELETE";
+    const HTTP_METHOD_GET = "GET";
     const JSON_KEY_UPLOADS = "uploads";
     const JSON_KEY_ERROR = "error";
     const JSON_KEY_COMPARISON_READY = "comparisonReady";
+    const JSON_KEY_TASK_ID = "taskID";
+    const JSON_KEY_TOTAL = "total";
+    const JSON_KEY_COMPLETED = "completed";
+    const JSON_KEY_STATUS = "status";
+    const JSON_KEY_ERRORS = "errors";
 
     const CLASS_DROPZONE_ACTIVE = "is-dragover";
     const CLASS_SECTION_TOGGLE = "section-toggle";
@@ -36,6 +47,8 @@
 
     const TEXT_UPLOAD_GENERIC_ERROR = "Upload failed. Please verify the file format.";
     const TEXT_RESET_GENERIC_ERROR = "Reset failed. Please try again.";
+    const TEXT_COMPARE_GENERIC_ERROR = "Unable to start comparison. Please try again.";
+    const TEXT_PROGRESS_GENERIC_ERROR = "Unable to retrieve comparison progress. Please try again.";
     const TEXT_UPLOAD_PLACEHOLDER = "No archives uploaded yet.";
     const TEXT_UNKNOWN = "Unknown";
     const TEXT_HANDLE_PREFIX = "@";
@@ -45,9 +58,18 @@
     const TEXT_NONE = "None";
     const TEXT_HIDE = "Hide";
     const TEXT_SHOW = "Show";
+    const TEXT_PROGRESS_PREFIX = "Resolved";
+    const TEXT_PROGRESS_SEPARATOR = "of";
+    const TEXT_HANDLES = "handles";
+    const TEXT_PROGRESS_WAIT = "Preparing comparison";
+    const TASK_STATUS_COMPLETED = "completed";
+    const TASK_STATUS_FAILED = "failed";
+    const PROGRESS_POLL_INTERVAL_MS = 1000;
 
     const PROFILE_BASE_URL = "https://twitter.com/";
     const FOLLOW_SCREEN_NAME_URL = "https://twitter.com/intent/follow?screen_name=";
+
+    let activeProgressPollHandle = null;
 
     initializeUploadUI();
     initializeMatrixFeatures();
@@ -62,13 +84,21 @@
         const placeholderElement = document.getElementById(ID_UPLOADS_PLACEHOLDER);
         const alertContainerElement = document.getElementById(ID_UPLOAD_ALERTS);
         const resetButtonElement = document.getElementById(ID_RESET_BUTTON);
+        const progressContainerElement = document.getElementById(ID_COMPARISON_PROGRESS);
+        const progressBarElement = document.getElementById(ID_COMPARISON_PROGRESS_BAR);
+        const progressTextElement = document.getElementById(ID_COMPARISON_PROGRESS_TEXT);
 
-        if (!fileInputElement || !dropzoneElement || !browseButtonElement || !compareButtonElement || !comparisonPanelElement || !uploadsListElement || !alertContainerElement) {
+        if (!fileInputElement || !dropzoneElement || !browseButtonElement || !compareButtonElement || !comparisonPanelElement || !uploadsListElement || !alertContainerElement || !progressContainerElement || !progressBarElement || !progressTextElement) {
             return;
         }
 
         const hasComparison = comparisonPanelElement.dataset.hasComparison === VALUE_TRUE;
         updateCompareButton(compareButtonElement, hasComparison);
+        resetProgressUI({
+            progressContainerElement,
+            progressBarElement,
+            progressTextElement,
+        });
 
         browseButtonElement.addEventListener("click", () => fileInputElement.click());
 
@@ -80,6 +110,9 @@
                     uploadsListElement,
                     placeholderElement,
                     alertContainerElement,
+                    progressContainerElement,
+                    progressBarElement,
+                    progressTextElement,
                 });
                 fileInputElement.value = "";
             }
@@ -104,12 +137,21 @@
                     uploadsListElement,
                     placeholderElement,
                     alertContainerElement,
+                    progressContainerElement,
+                    progressBarElement,
+                    progressTextElement,
                 });
             }
         });
 
         compareButtonElement.addEventListener("click", () => {
-            window.location.reload();
+            startComparisonTask({
+                compareButtonElement,
+                alertContainerElement,
+                progressContainerElement,
+                progressBarElement,
+                progressTextElement,
+            });
         });
 
         if (resetButtonElement) {
@@ -119,6 +161,9 @@
                     uploadsListElement,
                     placeholderElement,
                     alertContainerElement,
+                    progressContainerElement,
+                    progressBarElement,
+                    progressTextElement,
                 });
             });
         }
@@ -136,6 +181,7 @@
         }
 
         setAlertMessage(options.alertContainerElement, "", false);
+        resetProgressUI(options);
 
         fetch(ROUTE_UPLOADS, {
             method: HTTP_METHOD_POST,
@@ -169,9 +215,148 @@
             renderUploadsList([], options.uploadsListElement, options.placeholderElement);
             updateCompareButton(options.compareButtonElement, false);
             setAlertMessage(options.alertContainerElement, "", false);
+            resetProgressUI(options);
         }).catch(error => {
             setAlertMessage(options.alertContainerElement, error.message || TEXT_RESET_GENERIC_ERROR, true);
         });
+    }
+
+    function startComparisonTask(options) {
+        if (!options || !options.compareButtonElement) {
+            return;
+        }
+        stopActiveProgressPoll();
+        setAlertMessage(options.alertContainerElement, "", false);
+        options.compareButtonElement.setAttribute("disabled", VALUE_TRUE);
+        showProgressUI({
+            progressContainerElement: options.progressContainerElement,
+            progressBarElement: options.progressBarElement,
+            progressTextElement: options.progressTextElement,
+        }, 0, 0, true);
+
+        fetch(ROUTE_COMPARE, {
+            method: HTTP_METHOD_POST,
+        }).then(response => {
+            if (!response.ok) {
+                return response.json().catch(() => ({})).then(body => {
+                    throw new Error(body[JSON_KEY_ERROR] || TEXT_COMPARE_GENERIC_ERROR);
+                });
+            }
+            return response.json();
+        }).then(body => {
+            const taskIdentifier = typeof body[JSON_KEY_TASK_ID] === "string" ? body[JSON_KEY_TASK_ID] : "";
+            const totalCount = Number(body[JSON_KEY_TOTAL] || 0);
+            if (!taskIdentifier) {
+                throw new Error(TEXT_COMPARE_GENERIC_ERROR);
+            }
+            if (totalCount === 0) {
+                window.location.reload();
+                return;
+            }
+            monitorComparisonTask(taskIdentifier, totalCount, options);
+        }).catch(error => {
+            resetProgressUI(options);
+            setAlertMessage(options.alertContainerElement, error.message || TEXT_COMPARE_GENERIC_ERROR, true);
+            updateCompareButton(options.compareButtonElement, true);
+        });
+    }
+
+    function monitorComparisonTask(taskIdentifier, totalCount, options) {
+        showProgressUI(options, 0, totalCount, false);
+
+        const pollProgress = () => {
+            fetch(`${ROUTE_COMPARE_PROGRESS}${encodeURIComponent(taskIdentifier)}`, {
+                method: HTTP_METHOD_GET,
+            }).then(response => {
+                if (!response.ok) {
+                    return response.json().catch(() => ({})).then(body => {
+                        throw new Error(body[JSON_KEY_ERROR] || TEXT_PROGRESS_GENERIC_ERROR);
+                    });
+                }
+                return response.json();
+            }).then(body => {
+                const completedCount = Number(body[JSON_KEY_COMPLETED] || 0);
+                const statusValue = typeof body[JSON_KEY_STATUS] === "string" ? body[JSON_KEY_STATUS] : "";
+                showProgressUI(options, completedCount, totalCount, false);
+                if (statusValue === TASK_STATUS_COMPLETED) {
+                    stopActiveProgressPoll();
+                    window.location.reload();
+                    return;
+                }
+                if (statusValue === TASK_STATUS_FAILED) {
+                    stopActiveProgressPoll();
+                    handleComparisonFailure(body[JSON_KEY_ERRORS], options);
+                    return;
+                }
+                activeProgressPollHandle = window.setTimeout(pollProgress, PROGRESS_POLL_INTERVAL_MS);
+            }).catch(error => {
+                stopActiveProgressPoll();
+                setAlertMessage(options.alertContainerElement, error.message || TEXT_PROGRESS_GENERIC_ERROR, true);
+                resetProgressUI(options);
+                updateCompareButton(options.compareButtonElement, true);
+            });
+        };
+
+        pollProgress();
+    }
+
+    function handleComparisonFailure(errorDetails, options) {
+        let message = TEXT_COMPARE_GENERIC_ERROR;
+        if (errorDetails && typeof errorDetails === "object") {
+            const formatted = [];
+            Object.keys(errorDetails).forEach(accountIdentifier => {
+                const detail = errorDetails[accountIdentifier];
+                if (typeof detail === "string" && detail.trim() !== "") {
+                    formatted.push(`${accountIdentifier}: ${detail}`);
+                }
+            });
+            if (formatted.length > 0) {
+                message = formatted.join("; ");
+            }
+        }
+        setAlertMessage(options.alertContainerElement, message, true);
+        resetProgressUI(options);
+        updateCompareButton(options.compareButtonElement, true);
+    }
+
+    function stopActiveProgressPoll() {
+        if (activeProgressPollHandle !== null) {
+            window.clearTimeout(activeProgressPollHandle);
+            activeProgressPollHandle = null;
+        }
+    }
+
+    function resetProgressUI(options) {
+        stopActiveProgressPoll();
+        if (!options || !options.progressContainerElement || !options.progressBarElement || !options.progressTextElement) {
+            return;
+        }
+        options.progressContainerElement.classList.add(CLASS_HIDDEN);
+        options.progressBarElement.style.width = "0%";
+        options.progressBarElement.textContent = "0%";
+        options.progressBarElement.setAttribute("aria-valuenow", "0");
+        options.progressTextElement.textContent = "";
+    }
+
+    function showProgressUI(options, completedCount, totalCount, isPending) {
+        if (!options || !options.progressContainerElement || !options.progressBarElement || !options.progressTextElement) {
+            return;
+        }
+        options.progressContainerElement.classList.remove(CLASS_HIDDEN);
+        if (isPending) {
+            options.progressBarElement.style.width = "0%";
+            options.progressBarElement.textContent = "0%";
+            options.progressBarElement.setAttribute("aria-valuenow", "0");
+            options.progressTextElement.textContent = TEXT_PROGRESS_WAIT;
+            return;
+        }
+        const boundedTotal = totalCount > 0 ? totalCount : 0;
+        const boundedCompleted = Math.min(Math.max(completedCount, 0), boundedTotal);
+        const percentage = boundedTotal === 0 ? 100 : Math.round((boundedCompleted / boundedTotal) * 100);
+        options.progressBarElement.style.width = `${percentage}%`;
+        options.progressBarElement.textContent = `${percentage}%`;
+        options.progressBarElement.setAttribute("aria-valuenow", String(percentage));
+        options.progressTextElement.textContent = `${TEXT_PROGRESS_PREFIX} ${boundedCompleted} ${TEXT_PROGRESS_SEPARATOR} ${boundedTotal} ${TEXT_HANDLES}`;
     }
 
     function renderUploadsList(uploads, listElement, placeholderElement) {

--- a/internal/matrix/web/templates/index.tmpl
+++ b/internal/matrix/web/templates/index.tmpl
@@ -67,6 +67,12 @@
                     {{ end }}
                 </div>
                 <div class="card-body" id="comparisonPanel" data-has-comparison="{{ if .HasComparison }}true{{ else }}false{{ end }}">
+                    <div id="comparisonProgress" class="mb-3 is-hidden">
+                        <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+                            <div class="progress-bar" id="comparisonProgressBar" style="width: 0%;" aria-valuenow="0">0%</div>
+                        </div>
+                        <p class="small text-muted mt-2 mb-0" id="comparisonProgressText"></p>
+                    </div>
                     {{ if .HasComparison }}
                         <nav class="nav nav-pills flex-wrap gap-2 mb-4" aria-label="Comparison sections">
                             <a class="btn btn-outline-primary" href="#overview">Overview</a>

--- a/internal/server/resolution.go
+++ b/internal/server/resolution.go
@@ -1,0 +1,127 @@
+package server
+
+import (
+	"fmt"
+	"sync"
+)
+
+const (
+	handleResolutionTaskPrefix          = "task-"
+	handleResolutionStatusRunning       = handleResolutionStatus("running")
+	handleResolutionStatusCompleted     = handleResolutionStatus("completed")
+	handleResolutionStatusFailed        = handleResolutionStatus("failed")
+	handleResolutionTaskNotFoundMessage = "comparison task not found"
+)
+
+// handleResolutionStatus represents the lifecycle state of a handle resolution task.
+type handleResolutionStatus string
+
+// handleResolutionTask captures state for a handle resolution execution.
+type handleResolutionTask struct {
+	identifier string
+	total      int
+	completed  int
+	status     handleResolutionStatus
+	errors     map[string]string
+}
+
+// handleResolutionTaskSnapshot copies the public portions of a task for serialization.
+type handleResolutionTaskSnapshot struct {
+	Identifier string
+	Total      int
+	Completed  int
+	Status     handleResolutionStatus
+	Errors     map[string]string
+}
+
+// handleResolutionTracker tracks active and completed resolution tasks.
+type handleResolutionTracker struct {
+	mutex        sync.Mutex
+	tasks        map[string]*handleResolutionTask
+	nextSequence int
+}
+
+// newHandleResolutionTracker constructs a tracker with empty state.
+func newHandleResolutionTracker() *handleResolutionTracker {
+	return &handleResolutionTracker{tasks: make(map[string]*handleResolutionTask)}
+}
+
+// CreateTask registers a new resolution task and returns its snapshot.
+func (tracker *handleResolutionTracker) CreateTask(total int) handleResolutionTaskSnapshot {
+	tracker.mutex.Lock()
+	defer tracker.mutex.Unlock()
+
+	tracker.nextSequence++
+	identifier := fmt.Sprintf("%s%d", handleResolutionTaskPrefix, tracker.nextSequence)
+	task := &handleResolutionTask{
+		identifier: identifier,
+		total:      total,
+		status:     handleResolutionStatusRunning,
+		errors:     make(map[string]string),
+	}
+	tracker.tasks[identifier] = task
+	return tracker.snapshotTask(task)
+}
+
+// RecordResolution updates task progress for an account identifier and optional error.
+func (tracker *handleResolutionTracker) RecordResolution(taskIdentifier string, accountIdentifier string, resolutionErr error) {
+	tracker.mutex.Lock()
+	defer tracker.mutex.Unlock()
+
+	task, exists := tracker.tasks[taskIdentifier]
+	if !exists {
+		return
+	}
+	if resolutionErr != nil {
+		task.errors[accountIdentifier] = resolutionErr.Error()
+	}
+	task.completed++
+	if task.completed > task.total {
+		task.completed = task.total
+	}
+}
+
+// CompleteTask transitions a task to its terminal status.
+func (tracker *handleResolutionTracker) CompleteTask(taskIdentifier string, failed bool) {
+	tracker.mutex.Lock()
+	defer tracker.mutex.Unlock()
+
+	task, exists := tracker.tasks[taskIdentifier]
+	if !exists {
+		return
+	}
+	if failed {
+		task.status = handleResolutionStatusFailed
+	} else {
+		task.status = handleResolutionStatusCompleted
+	}
+	if task.completed < task.total {
+		task.completed = task.total
+	}
+}
+
+// TaskSnapshot returns a copy of the task state for external observers.
+func (tracker *handleResolutionTracker) TaskSnapshot(taskIdentifier string) (handleResolutionTaskSnapshot, bool) {
+	tracker.mutex.Lock()
+	defer tracker.mutex.Unlock()
+
+	task, exists := tracker.tasks[taskIdentifier]
+	if !exists {
+		return handleResolutionTaskSnapshot{}, false
+	}
+	return tracker.snapshotTask(task), true
+}
+
+func (tracker *handleResolutionTracker) snapshotTask(task *handleResolutionTask) handleResolutionTaskSnapshot {
+	clonedErrors := make(map[string]string, len(task.errors))
+	for accountIdentifier, message := range task.errors {
+		clonedErrors[accountIdentifier] = message
+	}
+	return handleResolutionTaskSnapshot{
+		Identifier: task.identifier,
+		Total:      task.total,
+		Completed:  task.completed,
+		Status:     task.status,
+		Errors:     clonedErrors,
+	}
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -20,6 +20,8 @@ const (
 	comparisonRoutePath             = "/"
 	healthRoutePath                 = "/healthz"
 	uploadsRoutePath                = "/api/uploads"
+	compareStartRoutePath           = "/api/compare"
+	compareProgressRoutePath        = "/api/compare/:taskID"
 	staticRoutePath                 = "/static"
 	htmlContentType                 = "text/html; charset=utf-8"
 	jsonContentType                 = "application/json; charset=utf-8"
@@ -36,14 +38,19 @@ const (
 	errMessageStoreUpdate           = "unable to store uploaded archive"
 	errMessageTooManyArchives       = "two archives already uploaded; reset before adding more"
 	errMessageRenderFailure         = "comparison page rendering failed"
+	errMessageHandleResolverMissing = "handle resolver is not configured"
+	errMessageComparisonUnavailable = "comparison is not ready; upload two archives first"
 	errMessageUploadPersistFailure  = "unable to persist uploaded file"
+	errMessageTaskUnknown           = handleResolutionTaskNotFoundMessage
 	logMessageRenderFailure         = "comparison render failure"
 	logMessageStoreFailure          = "upload store failure"
 	logMessageArchiveParseFailure   = "archive parse failure"
-	logMessageHandleResolution      = "resolving handles"
+	logMessageHandleResolutionStart = "starting handle resolution task"
 	logMessageHandleResolutionError = "handle resolution failure"
 	logFieldArchiveName             = "archive"
 	logFieldAccountID               = "account_id"
+	logFieldTaskID                  = "task_id"
+	logFieldTotalAccounts           = "total_accounts"
 	ginModeRelease                  = "release"
 )
 
@@ -58,6 +65,8 @@ type ComparisonData struct {
 	AccountSetsB matrix.AccountSets
 	OwnerA       matrix.OwnerIdentity
 	OwnerB       matrix.OwnerIdentity
+	FileNameA    string
+	FileNameB    string
 }
 
 // ComparisonService encapsulates the logic required to build and render comparison pages.
@@ -92,7 +101,7 @@ type ComparisonStore interface {
 	Snapshot() ComparisonSnapshot
 	Upsert(upload ArchiveUpload) (ComparisonSnapshot, error)
 	Clear() ComparisonSnapshot
-	ResolveHandles(ctx context.Context, resolver matrix.AccountHandleResolver) map[string]error
+	ApplyResolvedComparison(resolved ComparisonData)
 }
 
 // ComparisonSnapshot represents the current upload state and optional comparison data.
@@ -138,12 +147,15 @@ func NewRouter(configuration RouterConfig) (*gin.Engine, error) {
 		service:        service,
 		logger:         logger,
 		handleResolver: configuration.HandleResolver,
+		taskTracker:    newHandleResolutionTracker(),
 	}
 
 	engine.GET(comparisonRoutePath, handler.serveComparison)
 	engine.GET(healthRoutePath, handler.healthStatus)
 	engine.POST(uploadsRoutePath, handler.uploadArchives)
 	engine.DELETE(uploadsRoutePath, handler.resetArchives)
+	engine.POST(compareStartRoutePath, handler.startComparisonTask)
+	engine.GET(compareProgressRoutePath, handler.comparisonProgress)
 
 	return engine, nil
 }
@@ -153,6 +165,7 @@ type applicationHandler struct {
 	service        ComparisonService
 	logger         *zap.Logger
 	handleResolver matrix.AccountHandleResolver
+	taskTracker    *handleResolutionTracker
 }
 
 func (handler applicationHandler) serveComparison(ginContext *gin.Context) {
@@ -231,11 +244,6 @@ func (handler applicationHandler) uploadArchives(ginContext *gin.Context) {
 		}
 	}
 
-	if handler.handleResolver != nil && snapshot.ComparisonData != nil {
-		handler.logger.Info(logMessageHandleResolution)
-		go handler.resolveHandlesAsync()
-	}
-
 	ginContext.Header("Content-Type", jsonContentType)
 	ginContext.JSON(http.StatusOK, uploadResponse{
 		Uploads:         snapshot.Uploads,
@@ -248,11 +256,96 @@ func (handler applicationHandler) resetArchives(ginContext *gin.Context) {
 	ginContext.Status(http.StatusNoContent)
 }
 
-func (handler applicationHandler) resolveHandlesAsync() {
-	errorsByAccountID := handler.store.ResolveHandles(context.Background(), handler.handleResolver)
-	for accountID, resolutionErr := range errorsByAccountID {
-		handler.logger.Warn(logMessageHandleResolutionError, zap.String(logFieldAccountID, accountID), zap.Error(resolutionErr))
+func (handler applicationHandler) startComparisonTask(ginContext *gin.Context) {
+	if handler.handleResolver == nil {
+		handler.writeJSONError(ginContext, http.StatusBadRequest, errMessageHandleResolverMissing)
+		return
 	}
+
+	snapshot := handler.store.Snapshot()
+	if snapshot.ComparisonData == nil {
+		handler.writeJSONError(ginContext, http.StatusBadRequest, errMessageComparisonUnavailable)
+		return
+	}
+
+	resolutionPlan := matrix.NewHandleResolutionPlan(
+		&snapshot.ComparisonData.AccountSetsA,
+		&snapshot.ComparisonData.AccountSetsB,
+	)
+
+	taskSnapshot := handler.taskTracker.CreateTask(resolutionPlan.TargetCount())
+	handler.logger.Info(
+		logMessageHandleResolutionStart,
+		zap.String(logFieldTaskID, taskSnapshot.Identifier),
+		zap.Int(logFieldTotalAccounts, taskSnapshot.Total),
+	)
+
+	ginContext.Header("Content-Type", jsonContentType)
+	ginContext.JSON(http.StatusAccepted, startComparisonResponse{TaskID: taskSnapshot.Identifier, Total: taskSnapshot.Total})
+
+	if taskSnapshot.Total == 0 {
+		handler.store.ApplyResolvedComparison(*snapshot.ComparisonData)
+		handler.taskTracker.CompleteTask(taskSnapshot.Identifier, false)
+		return
+	}
+
+	go handler.executeHandleResolutionTask(taskSnapshot.Identifier, snapshot.ComparisonData, resolutionPlan)
+}
+
+func (handler applicationHandler) comparisonProgress(ginContext *gin.Context) {
+	taskIdentifier := ginContext.Param("taskID")
+	taskSnapshot, exists := handler.taskTracker.TaskSnapshot(taskIdentifier)
+	if !exists {
+		handler.writeJSONError(ginContext, http.StatusNotFound, errMessageTaskUnknown)
+		return
+	}
+
+	ginContext.Header("Content-Type", jsonContentType)
+	ginContext.JSON(http.StatusOK, comparisonProgressResponse{
+		TaskID:    taskSnapshot.Identifier,
+		Total:     taskSnapshot.Total,
+		Completed: taskSnapshot.Completed,
+		Status:    string(taskSnapshot.Status),
+		Errors:    taskSnapshot.Errors,
+	})
+}
+
+func (handler applicationHandler) executeHandleResolutionTask(taskIdentifier string, comparisonData *ComparisonData, plan matrix.HandleResolutionPlan) {
+	if handler.handleResolver == nil {
+		handler.taskTracker.CompleteTask(taskIdentifier, true)
+		return
+	}
+
+	ctx := context.Background()
+	accountIdentifiers := plan.AccountIDs()
+	taskFailed := false
+	for _, accountIdentifier := range accountIdentifiers {
+		results := handler.handleResolver.ResolveMany(ctx, []string{accountIdentifier})
+		result, exists := results[accountIdentifier]
+		var resolutionErr error
+		if !exists {
+			resolutionErr = matrix.ErrMissingHandleResolution
+		} else if result.Err != nil {
+			resolutionErr = result.Err
+		} else {
+			plan.ApplyResolvedRecord(accountIdentifier, result.Record)
+		}
+		if resolutionErr != nil {
+			taskFailed = true
+			handler.logger.Warn(
+				logMessageHandleResolutionError,
+				zap.String(logFieldTaskID, taskIdentifier),
+				zap.String(logFieldAccountID, accountIdentifier),
+				zap.Error(resolutionErr),
+			)
+		}
+		handler.taskTracker.RecordResolution(taskIdentifier, accountIdentifier, resolutionErr)
+	}
+
+	if comparisonData != nil {
+		handler.store.ApplyResolvedComparison(*comparisonData)
+	}
+	handler.taskTracker.CompleteTask(taskIdentifier, taskFailed)
 }
 
 func (handler applicationHandler) saveUploadedFile(ginContext *gin.Context, fileHeader *multipart.FileHeader) (string, func(), error) {
@@ -285,6 +378,19 @@ type uploadResponse struct {
 
 type errorResponse struct {
 	Error string `json:"error"`
+}
+
+type startComparisonResponse struct {
+	TaskID string `json:"taskID"`
+	Total  int    `json:"total"`
+}
+
+type comparisonProgressResponse struct {
+	TaskID    string            `json:"taskID"`
+	Total     int               `json:"total"`
+	Completed int               `json:"completed"`
+	Status    string            `json:"status"`
+	Errors    map[string]string `json:"errors,omitempty"`
 }
 
 type memoryComparisonStore struct {
@@ -351,29 +457,22 @@ func (store *memoryComparisonStore) Clear() ComparisonSnapshot {
 	return store.snapshotLocked()
 }
 
-func (store *memoryComparisonStore) ResolveHandles(ctx context.Context, resolver matrix.AccountHandleResolver) map[string]error {
-	store.mutex.RLock()
-	if store.primary == nil || store.secondary == nil {
-		store.mutex.RUnlock()
-		return nil
-	}
-	primary := *store.primary
-	secondary := *store.secondary
-	store.mutex.RUnlock()
-
-	accountSetsPrimary := copyAccountSets(primary.accountSets)
-	accountSetsSecondary := copyAccountSets(secondary.accountSets)
-	errorsByAccountID := matrix.ResolveHandles(ctx, resolver, &accountSetsPrimary, &accountSetsSecondary)
-
+func (store *memoryComparisonStore) ApplyResolvedComparison(resolved ComparisonData) {
 	store.mutex.Lock()
-	if store.primary != nil && (sameOwner(store.primary.owner, primary.owner) || sameFileForUnknownOwner(*store.primary, primary)) {
-		store.primary.accountSets = accountSetsPrimary
+	defer store.mutex.Unlock()
+
+	if store.primary != nil {
+		resolvedPrimary := archiveRecord{owner: resolved.OwnerA, fileName: resolved.FileNameA}
+		if sameOwner(store.primary.owner, resolved.OwnerA) || sameFileForUnknownOwner(*store.primary, resolvedPrimary) {
+			store.primary.accountSets = copyAccountSets(resolved.AccountSetsA)
+		}
 	}
-	if store.secondary != nil && (sameOwner(store.secondary.owner, secondary.owner) || sameFileForUnknownOwner(*store.secondary, secondary)) {
-		store.secondary.accountSets = accountSetsSecondary
+	if store.secondary != nil {
+		resolvedSecondary := archiveRecord{owner: resolved.OwnerB, fileName: resolved.FileNameB}
+		if sameOwner(store.secondary.owner, resolved.OwnerB) || sameFileForUnknownOwner(*store.secondary, resolvedSecondary) {
+			store.secondary.accountSets = copyAccountSets(resolved.AccountSetsB)
+		}
 	}
-	store.mutex.Unlock()
-	return errorsByAccountID
 }
 
 func (store *memoryComparisonStore) snapshotLocked() ComparisonSnapshot {
@@ -391,6 +490,8 @@ func (store *memoryComparisonStore) snapshotLocked() ComparisonSnapshot {
 			AccountSetsB: copyAccountSets(store.secondary.accountSets),
 			OwnerA:       store.primary.owner,
 			OwnerB:       store.secondary.owner,
+			FileNameA:    store.primary.fileName,
+			FileNameB:    store.secondary.fileName,
 		}
 	}
 	return ComparisonSnapshot{Uploads: uploads, ComparisonData: comparison}

--- a/tests/compare_progress_test.go
+++ b/tests/compare_progress_test.go
@@ -1,0 +1,231 @@
+package tests
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/f-sync/fsync/internal/handles"
+	"github.com/f-sync/fsync/internal/server"
+)
+
+const (
+	integrationOwnerAccountIDA     = "1"
+	integrationOwnerAccountIDB     = "2"
+	integrationFollowingAccountIDA = "10"
+	integrationFollowerAccountIDA  = "11"
+	integrationBlockedAccountIDA   = "100"
+	integrationFollowingAccountIDB = "20"
+	integrationFollowerAccountIDB  = "21"
+	integrationBlockedAccountIDB   = "200"
+	integrationResolvedHandleA     = "blocked_handle_a"
+	integrationResolvedNameA       = "Blocked Name A"
+	integrationResolvedHandleB     = "blocked_handle_b"
+	integrationResolvedNameB       = "Blocked Name B"
+	integrationProgressTimeout     = 10 * time.Second
+	integrationProgressPollDelay   = 200 * time.Millisecond
+)
+
+type comparisonTaskResponse struct {
+	TaskID string `json:"taskID"`
+	Total  int    `json:"total"`
+}
+
+type comparisonProgressResponse struct {
+	Status    string            `json:"status"`
+	Completed int               `json:"completed"`
+	Errors    map[string]string `json:"errors"`
+}
+
+type handleResolverStub struct {
+	results map[string]handles.Result
+}
+
+func (stub handleResolverStub) ResolveMany(_ context.Context, accountIDs []string) map[string]handles.Result {
+	resolved := make(map[string]handles.Result, len(accountIDs))
+	for _, accountID := range accountIDs {
+		if result, exists := stub.results[accountID]; exists {
+			resolved[accountID] = result
+		}
+	}
+	return resolved
+}
+
+func TestComparisonProgressLifecycle(t *testing.T) {
+	testCases := []struct {
+		name string
+	}{
+		{name: "resolves handles and completes"},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			resolver := handleResolverStub{results: map[string]handles.Result{
+				integrationFollowingAccountIDA: {Record: handles.AccountRecord{AccountID: integrationFollowingAccountIDA, UserName: "friend_a"}},
+				integrationFollowerAccountIDA:  {Record: handles.AccountRecord{AccountID: integrationFollowerAccountIDA, UserName: "follower_a"}},
+				integrationBlockedAccountIDA:   {Record: handles.AccountRecord{AccountID: integrationBlockedAccountIDA, UserName: integrationResolvedHandleA, DisplayName: integrationResolvedNameA}},
+				integrationFollowingAccountIDB: {Record: handles.AccountRecord{AccountID: integrationFollowingAccountIDB, UserName: "friend_b"}},
+				integrationFollowerAccountIDB:  {Record: handles.AccountRecord{AccountID: integrationFollowerAccountIDB, UserName: "follower_b"}},
+				integrationBlockedAccountIDB:   {Record: handles.AccountRecord{AccountID: integrationBlockedAccountIDB, UserName: integrationResolvedHandleB, DisplayName: integrationResolvedNameB}},
+			}}
+
+			router, err := server.NewRouter(server.RouterConfig{HandleResolver: resolver})
+			if err != nil {
+				t.Fatalf("NewRouter returned error: %v", err)
+			}
+
+			archiveA := createArchive(t, map[string]string{
+				"manifest.js":  fmt.Sprintf(`{"userInfo":{"accountId":"%s","userName":"owner_a","displayName":"Owner A"}}`, integrationOwnerAccountIDA),
+				"following.js": fmt.Sprintf(`[{"following":{"accountId":"%s"}}]`, integrationFollowingAccountIDA),
+				"follower.js":  fmt.Sprintf(`[{"follower":{"accountId":"%s"}}]`, integrationFollowerAccountIDA),
+				"block.js":     fmt.Sprintf(`[{"blocking":{"accountId":"%s"}}]`, integrationBlockedAccountIDA),
+			})
+			archiveB := createArchive(t, map[string]string{
+				"manifest.js":  fmt.Sprintf(`{"userInfo":{"accountId":"%s","userName":"owner_b","displayName":"Owner B"}}`, integrationOwnerAccountIDB),
+				"following.js": fmt.Sprintf(`[{"following":{"accountId":"%s"}}]`, integrationFollowingAccountIDB),
+				"follower.js":  fmt.Sprintf(`[{"follower":{"accountId":"%s"}}]`, integrationFollowerAccountIDB),
+				"block.js":     fmt.Sprintf(`[{"blocking":{"accountId":"%s"}}]`, integrationBlockedAccountIDB),
+			})
+
+			recorder := httptest.NewRecorder()
+			request := newUploadRequest(t, archiveA)
+			router.ServeHTTP(recorder, request)
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
+			}
+
+			recorder = httptest.NewRecorder()
+			request = newUploadRequest(t, archiveB)
+			router.ServeHTTP(recorder, request)
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
+			}
+
+			recorder = httptest.NewRecorder()
+			request = httptest.NewRequest(http.MethodPost, "/api/compare", nil)
+			router.ServeHTTP(recorder, request)
+			if recorder.Code != http.StatusAccepted {
+				t.Fatalf("expected status %d, got %d", http.StatusAccepted, recorder.Code)
+			}
+			var task comparisonTaskResponse
+			if err := json.Unmarshal(recorder.Body.Bytes(), &task); err != nil {
+				t.Fatalf("decode task response: %v", err)
+			}
+			if task.TaskID == "" {
+				t.Fatalf("task identifier missing in response")
+			}
+
+			waitForTaskCompletion(t, router, task.TaskID)
+
+			recorder = httptest.NewRecorder()
+			request = httptest.NewRequest(http.MethodGet, "/", nil)
+			router.ServeHTTP(recorder, request)
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
+			}
+			body := recorder.Body.String()
+			if !containsAll(body, integrationResolvedHandleA, integrationResolvedHandleB) {
+				t.Fatalf("expected comparison HTML to contain resolved handles, got %s", body)
+			}
+		})
+	}
+}
+
+func waitForTaskCompletion(t *testing.T, handler http.Handler, taskID string) {
+	t.Helper()
+	deadline := time.Now().Add(integrationProgressTimeout)
+	for time.Now().Before(deadline) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/compare/%s", taskID), nil)
+		handler.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("unexpected progress status %d: %s", recorder.Code, recorder.Body.String())
+		}
+		var progress comparisonProgressResponse
+		if err := json.Unmarshal(recorder.Body.Bytes(), &progress); err != nil {
+			t.Fatalf("decode progress response: %v", err)
+		}
+		if progress.Status == "completed" {
+			if len(progress.Errors) != 0 {
+				t.Fatalf("expected no resolution errors, got %v", progress.Errors)
+			}
+			return
+		}
+		time.Sleep(integrationProgressPollDelay)
+	}
+	t.Fatalf("comparison task %s did not complete", taskID)
+}
+
+func createArchive(t *testing.T, files map[string]string) string {
+	t.Helper()
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "archive.zip")
+
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	defer file.Close()
+
+	writer := zip.NewWriter(file)
+	for name, content := range files {
+		entry, err := writer.Create(name)
+		if err != nil {
+			t.Fatalf("create archive entry: %v", err)
+		}
+		if _, err := entry.Write([]byte(content)); err != nil {
+			t.Fatalf("write archive entry: %v", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close archive writer: %v", err)
+	}
+	return archivePath
+}
+
+func newUploadRequest(t *testing.T, archivePath string) *http.Request {
+	t.Helper()
+	file, err := os.Open(archivePath)
+	if err != nil {
+		t.Fatalf("open archive: %v", err)
+	}
+	defer file.Close()
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("archives", filepath.Base(archivePath))
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := io.Copy(part, file); err != nil {
+		t.Fatalf("copy archive: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/api/uploads", body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	return request
+}
+
+func containsAll(haystack string, values ...string) bool {
+	for _, value := range values {
+		if !strings.Contains(haystack, value) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- move comparison handle resolution into a dedicated task tracker with new start/progress endpoints and updated store coordination
- add a reusable handle resolution plan in the matrix package and surface progress to the web UI with a polling-driven progress bar
- cover the new compare flow with updated server tests and a frontend-style integration test

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ccc1783b0c8327816e1793ed22897a