### PR TITLE
refactor: centralize chrome user agents

### DIFF
--- a/cmd/cresolve/main.go
+++ b/cmd/cresolve/main.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/f-sync/fsync/internal/handles"
 )
 
 const (
@@ -35,13 +37,6 @@ var (
 
 	metaOGTitle  = regexp.MustCompile(`property="og:title"[^>]*content="([^"]+)"`)
 	metaTitleTag = regexp.MustCompile(`<title[^>]*>([^<]+)</title>`)
-
-	uaPool = []string{
-		"Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.846.0 Safari/537.36",
-		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.846.0 Safari/537.36",
-		"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.846.0 Safari/537.36",
-		"Mozilla/5.0 (Macintosh; Intel Mac OS X 13_6_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.850.0 Safari/537.36",
-	}
 )
 
 type profileInfo struct {
@@ -142,7 +137,7 @@ func main() {
 
 func resolveOne(ctx context.Context, chromeBinaryPath string, vtBudgetMS int, id string) profileInfo {
 	intentURL := "https://x.com/intent/user?user_id=" + id
-	userAgent := uaPool[rand.Intn(len(uaPool))]
+	userAgent := handles.DefaultChromeUserAgent(nil)
 
 	htmlDoc, err := renderWithHeadlessChrome(ctx, chromeBinaryPath, userAgent, vtBudgetMS, intentURL)
 	if err != nil || strings.TrimSpace(htmlDoc) == "" {

--- a/internal/handles/intent_fetcher.go
+++ b/internal/handles/intent_fetcher.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,7 +15,6 @@ import (
 
 const (
 	chromeBinaryEnvironmentVariable      = "CHROME_BIN"
-	defaultChromeUserAgent               = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
 	chromeUserAgentFlagFormat            = "--user-agent=%s"
 	chromeVirtualTimeBudgetFlagFormat    = "--virtual-time-budget=%d"
 	chromeDumpDOMFlag                    = "--dump-dom"
@@ -113,7 +113,8 @@ func NewChromeIntentFetcher(configuration ChromeFetcherConfig) (*ChromeIntentFet
 
 	userAgent := strings.TrimSpace(configuration.UserAgent)
 	if userAgent == "" {
-		userAgent = defaultChromeUserAgent
+		randomGenerator := rand.New(rand.NewSource(time.Now().UnixNano()))
+		userAgent = DefaultChromeUserAgent(randomGenerator)
 	}
 
 	virtualTimeBudget := configuration.VirtualTimeBudget

--- a/internal/handles/intent_fetcher_test.go
+++ b/internal/handles/intent_fetcher_test.go
@@ -1,0 +1,122 @@
+package handles_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/f-sync/fsync/internal/handles"
+)
+
+const (
+	argumentPrinterScriptName        = "print_args.sh"
+	argumentPrinterScriptContent     = "#!/bin/sh\nfor argument in \"$@\"; do\n        printf '%s\\n' \"$argument\"\ndone\n"
+	chromeUserAgentArgumentPrefix    = "--user-agent="
+	fetcherTestIntentAccountID       = "40001"
+	fetcherTestIntentURLTemplate     = "https://x.com/intent/user?user_id=%s"
+	fetcherTestCustomUserAgentString = "CustomAgent/200.0"
+)
+
+func TestChromeIntentFetcherUserAgentSelection(t *testing.T) {
+	t.Parallel()
+
+	argumentPrinterPath := createArgumentPrinterScript(t)
+	allowedAgents := handles.DefaultChromeUserAgents()
+	if len(allowedAgents) == 0 {
+		t.Fatalf("expected modern user agent list to be non-empty")
+	}
+
+	testCases := []struct {
+		name                string
+		configuredUserAgent string
+		expectExactMatch    bool
+	}{
+		{
+			name:                "defaults to modern user agent",
+			configuredUserAgent: "",
+		},
+		{
+			name:                "uses explicit user agent",
+			configuredUserAgent: fetcherTestCustomUserAgentString,
+			expectExactMatch:    true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			fetcher, fetcherErr := handles.NewChromeIntentFetcher(handles.ChromeFetcherConfig{
+				BinaryPath:        argumentPrinterPath,
+				UserAgent:         testCase.configuredUserAgent,
+				VirtualTimeBudget: 0,
+				RequestDelay:      -1,
+			})
+			if fetcherErr != nil {
+				t.Fatalf("create fetcher: %v", fetcherErr)
+			}
+
+			intentURL := fmt.Sprintf(fetcherTestIntentURLTemplate, fetcherTestIntentAccountID)
+			intentRequest := handles.IntentRequest{AccountID: fetcherTestIntentAccountID, URL: intentURL}
+
+			intentPage, fetchErr := fetcher.FetchIntentPage(context.Background(), intentRequest)
+			if fetchErr != nil {
+				t.Fatalf("fetch intent page: %v", fetchErr)
+			}
+
+			userAgentArgument := extractUserAgentArgument(intentPage.HTML)
+			if userAgentArgument == "" {
+				t.Fatalf("user agent argument not present in command output: %s", intentPage.HTML)
+			}
+			actualUserAgent := strings.TrimPrefix(userAgentArgument, chromeUserAgentArgumentPrefix)
+
+			if testCase.expectExactMatch {
+				if actualUserAgent != testCase.configuredUserAgent {
+					t.Fatalf("expected explicit user agent %s, received %s", testCase.configuredUserAgent, actualUserAgent)
+				}
+				return
+			}
+
+			if !agentInSet(actualUserAgent, allowedAgents) {
+				t.Fatalf("expected modern user agent, received %s", actualUserAgent)
+			}
+		})
+	}
+}
+
+func createArgumentPrinterScript(t *testing.T) string {
+	t.Helper()
+	temporaryDirectory := t.TempDir()
+	scriptPath := filepath.Join(temporaryDirectory, argumentPrinterScriptName)
+	if writeErr := os.WriteFile(scriptPath, []byte(argumentPrinterScriptContent), 0o755); writeErr != nil {
+		t.Fatalf("write argument printer script: %v", writeErr)
+	}
+	if chmodErr := os.Chmod(scriptPath, 0o755); chmodErr != nil {
+		t.Fatalf("set script executable: %v", chmodErr)
+	}
+	return scriptPath
+}
+
+func extractUserAgentArgument(output string) string {
+	outputLines := strings.Split(strings.TrimSpace(output), "\n")
+	for _, line := range outputLines {
+		trimmedLine := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmedLine, chromeUserAgentArgumentPrefix) {
+			return trimmedLine
+		}
+	}
+	return ""
+}
+
+func agentInSet(candidate string, agents []string) bool {
+	for _, agent := range agents {
+		if candidate == agent {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/handles/user_agent.go
+++ b/internal/handles/user_agent.go
@@ -1,0 +1,63 @@
+package handles
+
+import (
+	"math/rand"
+)
+
+const (
+	// ChromeUserAgentMacOSSonoma141 identifies a recent Chrome build on macOS Sonoma.
+	ChromeUserAgentMacOSSonoma141 = "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.846.0 Safari/537.36"
+	// ChromeUserAgentWindows141 identifies a recent Chrome build on Windows 10.
+	ChromeUserAgentWindows141 = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.846.0 Safari/537.36"
+	// ChromeUserAgentLinux141 identifies a recent Chrome build on Linux.
+	ChromeUserAgentLinux141 = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.846.0 Safari/537.36"
+	// ChromeUserAgentMacOSVentura141 identifies a recent Chrome build on macOS Ventura.
+	ChromeUserAgentMacOSVentura141 = "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_6_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.850.0 Safari/537.36"
+)
+
+var (
+	defaultChromeUserAgentValues = []string{
+		ChromeUserAgentMacOSSonoma141,
+		ChromeUserAgentWindows141,
+		ChromeUserAgentLinux141,
+		ChromeUserAgentMacOSVentura141,
+	}
+
+	defaultChromeUserAgentProvider = NewChromeUserAgentProvider(defaultChromeUserAgentValues)
+)
+
+// ChromeUserAgentProvider selects Chrome user agent strings for outbound requests.
+type ChromeUserAgentProvider struct {
+	userAgents []string
+}
+
+// NewChromeUserAgentProvider constructs a ChromeUserAgentProvider with the supplied agent values.
+func NewChromeUserAgentProvider(userAgents []string) ChromeUserAgentProvider {
+	copiedUserAgents := make([]string, len(userAgents))
+	copy(copiedUserAgents, userAgents)
+	return ChromeUserAgentProvider{userAgents: copiedUserAgents}
+}
+
+// RandomAgent returns a user agent from the provider using the supplied random generator.
+// When the random generator is nil, the package-level math/rand functions are used.
+func (provider ChromeUserAgentProvider) RandomAgent(randomGenerator *rand.Rand) string {
+	if len(provider.userAgents) == 0 {
+		return ""
+	}
+	if randomGenerator != nil {
+		selectedIndex := randomGenerator.Intn(len(provider.userAgents))
+		return provider.userAgents[selectedIndex]
+	}
+	selectedIndex := rand.Intn(len(provider.userAgents))
+	return provider.userAgents[selectedIndex]
+}
+
+// DefaultChromeUserAgent returns a modern Chrome user agent string.
+func DefaultChromeUserAgent(randomGenerator *rand.Rand) string {
+	return defaultChromeUserAgentProvider.RandomAgent(randomGenerator)
+}
+
+// DefaultChromeUserAgents exposes the list of modern Chrome user agent strings.
+func DefaultChromeUserAgents() []string {
+	return append([]string{}, defaultChromeUserAgentProvider.userAgents...)
+}


### PR DESCRIPTION
## Summary
- centralize modern Chrome user agent strings in the handles package via a reusable provider
- update the CLI and Chrome intent fetcher to choose from the shared modern agent list
- add tests that assert Chrome invocations include one of the modern agents by default

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ccdab0c2348327ab5f0b5fa1d66afa