### PR TITLE
Refactor cresolve around reusable handle resolution service

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/f-sync/fsync/internal/handles"
+	"github.com/f-sync/fsync/internal/cresolver"
 	"github.com/f-sync/fsync/internal/server"
 )
 
@@ -76,7 +76,7 @@ func runServerCommand(*cobra.Command, []string) error {
 	}()
 
 	logger.Info(logMessageResolverInitialization)
-	resolver, resolverErr := handles.NewResolver(handles.Config{})
+	resolver, resolverErr := cresolver.NewService(cresolver.Config{})
 	if resolverErr != nil {
 		return fmt.Errorf("%s: %w", errMessageResolverCreate, resolverErr)
 	}

--- a/internal/cresolver/doc.go
+++ b/internal/cresolver/doc.go
@@ -1,0 +1,2 @@
+// Package cresolver provides services for resolving Twitter handles for numeric account identifiers.
+package cresolver

--- a/internal/cresolver/service.go
+++ b/internal/cresolver/service.go
@@ -1,0 +1,279 @@
+package cresolver
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/f-sync/fsync/internal/handles"
+	"github.com/f-sync/fsync/internal/matrix"
+)
+
+const (
+	defaultIntentBaseURL     = "https://x.com"
+	intentPathFormat         = "/intent/user?user_id=%s"
+	errMessageCreateResolver = "create account resolver"
+)
+
+// Config configures a Service instance.
+type Config struct {
+	Handles        handles.Config
+	AccountTimeout time.Duration
+	RequestPacing  RequestPacingConfig
+	IntentBaseURL  string
+	Resolver       AccountResolver
+}
+
+// RequestPacingConfig describes the pacing characteristics for handle resolution requests.
+type RequestPacingConfig struct {
+	BaseDelay       time.Duration
+	Jitter          time.Duration
+	BurstSize       int
+	BurstRest       time.Duration
+	BurstRestJitter time.Duration
+	RandomGenerator *rand.Rand
+}
+
+// Request captures the account identifiers to resolve.
+type Request struct {
+	AccountIDs []string
+}
+
+// AccountResolver resolves individual account identifiers.
+type AccountResolver interface {
+	ResolveAccount(ctx context.Context, accountID string) (handles.AccountRecord, error)
+}
+
+// AccountResolution represents the resolution outcome for a single identifier.
+type AccountResolution struct {
+	AccountID string
+	IntentURL string
+	Record    handles.AccountRecord
+	Err       error
+}
+
+// Service resolves numeric account identifiers into handle information.
+type Service struct {
+	resolver       AccountResolver
+	requestPacer   *requestPacer
+	accountTimeout time.Duration
+	intentBaseURL  string
+}
+
+var _ matrix.AccountHandleResolver = (*Service)(nil)
+
+// NewService constructs a Service from configuration values.
+func NewService(configuration Config) (*Service, error) {
+	resolver := configuration.Resolver
+	if resolver == nil {
+		handlesResolver, resolverErr := handles.NewResolver(configuration.Handles)
+		if resolverErr != nil {
+			return nil, fmt.Errorf("%s: %w", errMessageCreateResolver, resolverErr)
+		}
+		resolver = handlesResolver
+	}
+
+	service := &Service{
+		resolver:       resolver,
+		requestPacer:   newRequestPacer(configuration.RequestPacing),
+		accountTimeout: configuration.AccountTimeout,
+		intentBaseURL:  normalizeBaseURL(configuration.IntentBaseURL),
+	}
+	return service, nil
+}
+
+// ResolveBatch resolves the supplied account identifiers in order and returns their outcomes.
+func (service *Service) ResolveBatch(ctx context.Context, request Request) ([]AccountResolution, error) {
+	normalizedAccountIDs := service.normalizeAccountIDs(request.AccountIDs)
+	return service.resolveAccountIDs(ctx, normalizedAccountIDs)
+}
+
+// ResolveMany resolves the provided identifiers and satisfies the matrix.AccountHandleResolver interface.
+func (service *Service) ResolveMany(ctx context.Context, accountIDs []string) map[string]handles.Result {
+	normalizedAccountIDs := service.normalizeAccountIDs(accountIDs)
+	resolutions, resolveErr := service.resolveAccountIDs(ctx, normalizedAccountIDs)
+
+	results := make(map[string]handles.Result, len(normalizedAccountIDs))
+	for index, accountID := range normalizedAccountIDs {
+		if index < len(resolutions) {
+			resolution := resolutions[index]
+			results[accountID] = handles.Result{Record: resolution.Record, Err: resolution.Err}
+			continue
+		}
+		if resolveErr != nil {
+			results[accountID] = handles.Result{Err: resolveErr}
+		}
+	}
+	return results
+}
+
+func (service *Service) resolveAccountIDs(ctx context.Context, accountIDs []string) ([]AccountResolution, error) {
+	resolutions := make([]AccountResolution, 0, len(accountIDs))
+	if len(accountIDs) == 0 {
+		return resolutions, nil
+	}
+
+	for index, accountID := range accountIDs {
+		select {
+		case <-ctx.Done():
+			return resolutions, ctx.Err()
+		default:
+		}
+
+		resolutions = append(resolutions, service.resolveSingleAccount(ctx, accountID))
+
+		if index == len(accountIDs)-1 {
+			continue
+		}
+		if waitErr := service.waitForNext(ctx); waitErr != nil {
+			return resolutions, waitErr
+		}
+	}
+
+	return resolutions, nil
+}
+
+func (service *Service) resolveSingleAccount(ctx context.Context, accountID string) AccountResolution {
+	resolution := AccountResolution{
+		AccountID: accountID,
+		IntentURL: service.intentURL(accountID),
+	}
+
+	accountCtx := ctx
+	cancelAccount := func() {}
+	if service.accountTimeout > 0 {
+		var cancel context.CancelFunc
+		accountCtx, cancel = context.WithTimeout(ctx, service.accountTimeout)
+		cancelAccount = cancel
+	}
+	record, resolveErr := service.resolver.ResolveAccount(accountCtx, accountID)
+	cancelAccount()
+
+	resolution.Record = record
+	resolution.Err = resolveErr
+	return resolution
+}
+
+func (service *Service) waitForNext(ctx context.Context) error {
+	if service.requestPacer == nil {
+		return nil
+	}
+
+	delayDuration, restDuration := service.requestPacer.NextWaits()
+	if err := waitForDuration(ctx, delayDuration); err != nil {
+		return err
+	}
+	if err := waitForDuration(ctx, restDuration); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (service *Service) intentURL(accountID string) string {
+	return service.intentBaseURL + fmt.Sprintf(intentPathFormat, accountID)
+}
+
+func (service *Service) normalizeAccountIDs(accountIDs []string) []string {
+	normalized := make([]string, 0, len(accountIDs))
+	for _, accountID := range accountIDs {
+		trimmed := strings.TrimSpace(accountID)
+		if trimmed == "" {
+			continue
+		}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized
+}
+
+func waitForDuration(ctx context.Context, duration time.Duration) error {
+	if duration <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func normalizeBaseURL(intentBaseURL string) string {
+	trimmed := strings.TrimSpace(intentBaseURL)
+	if trimmed == "" {
+		trimmed = defaultIntentBaseURL
+	}
+	return strings.TrimRight(trimmed, "/")
+}
+
+type requestPacer struct {
+	baseDelay       time.Duration
+	jitter          time.Duration
+	burstSize       int
+	burstRest       time.Duration
+	burstRestJitter time.Duration
+
+	randomGenerator *rand.Rand
+	mutex           sync.Mutex
+	processed       int
+}
+
+func newRequestPacer(configuration RequestPacingConfig) *requestPacer {
+	baseDelay := configuration.BaseDelay
+	if baseDelay < 0 {
+		baseDelay = 0
+	}
+	burstRest := configuration.BurstRest
+	if burstRest < 0 {
+		burstRest = 0
+	}
+	randomGenerator := configuration.RandomGenerator
+	if randomGenerator == nil {
+		randomGenerator = rand.New(rand.NewSource(time.Now().UnixNano()))
+	}
+
+	return &requestPacer{
+		baseDelay:       baseDelay,
+		jitter:          configuration.Jitter,
+		burstSize:       configuration.BurstSize,
+		burstRest:       burstRest,
+		burstRestJitter: configuration.BurstRestJitter,
+		randomGenerator: randomGenerator,
+	}
+}
+
+func (pacer *requestPacer) NextWaits() (time.Duration, time.Duration) {
+	pacer.mutex.Lock()
+	defer pacer.mutex.Unlock()
+
+	pacer.processed++
+
+	delayDuration := pacer.sampleDuration(pacer.baseDelay, pacer.jitter)
+	var restDuration time.Duration
+	if pacer.burstSize > 0 && pacer.processed%pacer.burstSize == 0 {
+		restDuration = pacer.sampleDuration(pacer.burstRest, pacer.burstRestJitter)
+	}
+	return delayDuration, restDuration
+}
+
+func (pacer *requestPacer) sampleDuration(baseDuration time.Duration, jitter time.Duration) time.Duration {
+	if baseDuration < 0 {
+		baseDuration = 0
+	}
+	if jitter <= 0 {
+		return baseDuration
+	}
+
+	offset := (pacer.randomGenerator.Float64()*2 - 1) * float64(jitter)
+	sampled := time.Duration(float64(baseDuration) + offset)
+	if sampled < 0 {
+		return 0
+	}
+	return sampled
+}

--- a/internal/cresolver/service_test.go
+++ b/internal/cresolver/service_test.go
@@ -1,0 +1,305 @@
+package cresolver_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/f-sync/fsync/internal/cresolver"
+	"github.com/f-sync/fsync/internal/handles"
+)
+
+type accountResolverStub struct {
+	records      map[string]handles.AccountRecord
+	errors       map[string]error
+	callObserver func(callIndex int, accountID string, accountCtx context.Context)
+
+	callCount int
+}
+
+func (stub *accountResolverStub) ResolveAccount(ctx context.Context, accountID string) (handles.AccountRecord, error) {
+	callIndex := stub.callCount
+	stub.callCount++
+	if stub.callObserver != nil {
+		stub.callObserver(callIndex, accountID, ctx)
+	}
+	if stub.records != nil {
+		if record, exists := stub.records[accountID]; exists {
+			if stub.errors != nil {
+				if resolveErr, hasErr := stub.errors[accountID]; hasErr {
+					return record, resolveErr
+				}
+			}
+			return record, nil
+		}
+	}
+	if stub.errors != nil {
+		if resolveErr, hasErr := stub.errors[accountID]; hasErr {
+			return handles.AccountRecord{AccountID: accountID}, resolveErr
+		}
+	}
+	return handles.AccountRecord{AccountID: accountID}, nil
+}
+
+func TestServiceResolveBatch(t *testing.T) {
+	t.Parallel()
+
+	type expectedResolution struct {
+		accountID   string
+		userName    string
+		displayName string
+		intentURL   string
+		err         error
+	}
+
+	testCases := []struct {
+		name                string
+		requestIDs          []string
+		records             map[string]handles.AccountRecord
+		errors              map[string]error
+		config              cresolver.Config
+		observer            func(t *testing.T, callIndex int, accountID string, accountCtx context.Context)
+		expectedResolutions []expectedResolution
+		expectedErr         error
+	}{
+		{
+			name:       "resolves accounts in order",
+			requestIDs: []string{"108642770", "1118018827147567104"},
+			records: map[string]handles.AccountRecord{
+				"108642770":           {AccountID: "108642770", UserName: "jamesmarsh79", DisplayName: "James Marsh"},
+				"1118018827147567104": {AccountID: "1118018827147567104", UserName: "moon_of_a_moon", DisplayName: "Moon"},
+			},
+			expectedResolutions: []expectedResolution{
+				{
+					accountID:   "108642770",
+					userName:    "jamesmarsh79",
+					displayName: "James Marsh",
+					intentURL:   "https://x.com/intent/user?user_id=108642770",
+				},
+				{
+					accountID:   "1118018827147567104",
+					userName:    "moon_of_a_moon",
+					displayName: "Moon",
+					intentURL:   "https://x.com/intent/user?user_id=1118018827147567104",
+				},
+			},
+		},
+		{
+			name:       "skips blank identifiers",
+			requestIDs: []string{"   ", "1119714183119900673", ""},
+			records: map[string]handles.AccountRecord{
+				"1119714183119900673": {AccountID: "1119714183119900673", UserName: "ludditeengineer", DisplayName: "Mike"},
+			},
+			expectedResolutions: []expectedResolution{
+				{
+					accountID:   "1119714183119900673",
+					userName:    "ludditeengineer",
+					displayName: "Mike",
+					intentURL:   "https://x.com/intent/user?user_id=1119714183119900673",
+				},
+			},
+		},
+		{
+			name:       "includes resolver errors",
+			requestIDs: []string{"108642770", "unknown"},
+			records: map[string]handles.AccountRecord{
+				"108642770": {AccountID: "108642770", UserName: "jamesmarsh79", DisplayName: "James Marsh"},
+				"unknown":   {AccountID: "unknown"},
+			},
+			errors: map[string]error{
+				"unknown": errors.New("profile not found"),
+			},
+			expectedResolutions: []expectedResolution{
+				{
+					accountID:   "108642770",
+					userName:    "jamesmarsh79",
+					displayName: "James Marsh",
+					intentURL:   "https://x.com/intent/user?user_id=108642770",
+				},
+				{
+					accountID: "unknown",
+					intentURL: "https://x.com/intent/user?user_id=unknown",
+					err:       errors.New("profile not found"),
+				},
+			},
+		},
+		{
+			name:       "applies account timeout",
+			requestIDs: []string{"108642770"},
+			records: map[string]handles.AccountRecord{
+				"108642770": {AccountID: "108642770", UserName: "jamesmarsh79"},
+			},
+			config: cresolver.Config{AccountTimeout: 2 * time.Second},
+			observer: func(t *testing.T, callIndex int, accountID string, accountCtx context.Context) {
+				t.Helper()
+				deadline, exists := accountCtx.Deadline()
+				if !exists {
+					t.Fatalf("expected deadline for account %s", accountID)
+				}
+				if time.Until(deadline) > 2*time.Second || time.Until(deadline) <= 0 {
+					t.Fatalf("unexpected deadline duration for account %s", accountID)
+				}
+			},
+			expectedResolutions: []expectedResolution{
+				{
+					accountID: "108642770",
+					userName:  "jamesmarsh79",
+					intentURL: "https://x.com/intent/user?user_id=108642770",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			stub := &accountResolverStub{records: testCase.records, errors: testCase.errors}
+			if testCase.observer != nil {
+				stub.callObserver = func(callIndex int, accountID string, accountCtx context.Context) {
+					testCase.observer(t, callIndex, accountID, accountCtx)
+				}
+			}
+
+			configuration := testCase.config
+			configuration.Resolver = stub
+			service, err := cresolver.NewService(configuration)
+			if err != nil {
+				t.Fatalf("create service: %v", err)
+			}
+
+			ctx := context.Background()
+			resolutions, resolveErr := service.ResolveBatch(ctx, cresolver.Request{AccountIDs: testCase.requestIDs})
+			if !errors.Is(resolveErr, testCase.expectedErr) {
+				t.Fatalf("unexpected resolve error: %v", resolveErr)
+			}
+
+			if len(resolutions) != len(testCase.expectedResolutions) {
+				t.Fatalf("expected %d resolutions, received %d", len(testCase.expectedResolutions), len(resolutions))
+			}
+
+			for index, resolution := range resolutions {
+				expected := testCase.expectedResolutions[index]
+				if resolution.AccountID != expected.accountID {
+					t.Fatalf("expected account %s at index %d, received %s", expected.accountID, index, resolution.AccountID)
+				}
+				if resolution.Record.UserName != expected.userName {
+					t.Fatalf("expected user name %s for account %s, received %s", expected.userName, expected.accountID, resolution.Record.UserName)
+				}
+				if resolution.Record.DisplayName != expected.displayName {
+					t.Fatalf("expected display name %s for account %s, received %s", expected.displayName, expected.accountID, resolution.Record.DisplayName)
+				}
+				if resolution.IntentURL != expected.intentURL {
+					t.Fatalf("expected intent URL %s, received %s", expected.intentURL, resolution.IntentURL)
+				}
+				if expected.err != nil {
+					if resolution.Err == nil || resolution.Err.Error() != expected.err.Error() {
+						t.Fatalf("expected error %v for account %s, received %v", expected.err, expected.accountID, resolution.Err)
+					}
+				} else if resolution.Err != nil {
+					t.Fatalf("expected no error for account %s, received %v", expected.accountID, resolution.Err)
+				}
+			}
+		})
+	}
+}
+
+func TestServiceResolveBatchContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	cancelingStub := &accountResolverStub{
+		records: map[string]handles.AccountRecord{
+			"108642770":           {AccountID: "108642770", UserName: "jamesmarsh79"},
+			"1118018827147567104": {AccountID: "1118018827147567104", UserName: "moon_of_a_moon"},
+		},
+	}
+
+	service, err := cresolver.NewService(cresolver.Config{
+		Resolver: cancelingStub,
+		RequestPacing: cresolver.RequestPacingConfig{
+			BaseDelay: 10 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create service: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelingStub.callObserver = func(callIndex int, accountID string, accountCtx context.Context) {
+		if callIndex == 0 {
+			cancel()
+		}
+	}
+
+	resolutions, resolveErr := service.ResolveBatch(ctx, cresolver.Request{AccountIDs: []string{"108642770", "1118018827147567104"}})
+	if !errors.Is(resolveErr, context.Canceled) {
+		t.Fatalf("expected context cancellation error, received %v", resolveErr)
+	}
+	if len(resolutions) != 1 {
+		t.Fatalf("expected one resolution before cancellation, received %d", len(resolutions))
+	}
+	if resolutions[0].AccountID != "108642770" {
+		t.Fatalf("expected first account to be resolved before cancellation, received %s", resolutions[0].AccountID)
+	}
+}
+
+func TestServiceResolveMany(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		requestIDs       []string
+		stub             *accountResolverStub
+		cancelAfterFirst bool
+	}{
+		{
+			name:       "propagates context cancellation to remaining identifiers",
+			requestIDs: []string{"108642770", "1118018827147567104"},
+			stub: &accountResolverStub{
+				records: map[string]handles.AccountRecord{
+					"108642770":           {AccountID: "108642770", UserName: "jamesmarsh79"},
+					"1118018827147567104": {AccountID: "1118018827147567104", UserName: "moon_of_a_moon"},
+				},
+			},
+			cancelAfterFirst: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			if testCase.cancelAfterFirst {
+				testCase.stub.callObserver = func(callIndex int, accountID string, accountCtx context.Context) {
+					if callIndex == 0 {
+						cancel()
+					}
+				}
+			}
+
+			service, err := cresolver.NewService(cresolver.Config{Resolver: testCase.stub, RequestPacing: cresolver.RequestPacingConfig{BaseDelay: 5 * time.Millisecond}})
+			if err != nil {
+				t.Fatalf("create service: %v", err)
+			}
+
+			results := service.ResolveMany(ctx, testCase.requestIDs)
+			if len(results) != len(testCase.requestIDs) {
+				t.Fatalf("expected %d results, received %d", len(testCase.requestIDs), len(results))
+			}
+
+			first := results["108642770"]
+			if first.Err != nil {
+				t.Fatalf("expected first account to resolve without error, received %v", first.Err)
+			}
+
+			second := results["1118018827147567104"]
+			if !errors.Is(second.Err, context.Canceled) {
+				t.Fatalf("expected cancellation error for second account, received %v", second.Err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add an internal cresolver service that encapsulates handle lookups with pacing and per-request timeouts
- refactor the cresolve CLI to consume the service and keep presentation concerns in the command
- wire the HTTP server to the same service so the web app shares the resolver logic
- add table-driven tests that exercise the new service behavior

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68cce6b378b883278dab5611ec8df3d1