### PR TITLE
Add canonical profile link to xresolver HTML fixture

### DIFF
--- a/internal/xresolver/service_test.go
+++ b/internal/xresolver/service_test.go
@@ -36,13 +36,44 @@ func (r *stubRenderer) Render(ctx context.Context, userAgent, url string, vtBudg
 	return "", errors.New("unknown url")
 }
 
-func htmlFor(handle, name string) string {
+const (
+	htmlDocumentMetaPrefix      = `<html><head><meta property="og:title" content="`
+	htmlDocumentHeadSuffix      = `"></head>`
+	htmlDocumentBodyOpenTag     = `<body>`
+	htmlDocumentBodyCloseTag    = `</body></html>`
+	htmlAnchorOpenPrefix        = `<a href="`
+	htmlAnchorTextSeparator     = `">`
+	htmlAnchorCloseSuffix       = `</a>`
+	profileHandleURLPrefix      = `https://x.com/`
+	profileHandleDisplayPrefix  = `@`
+	profileHandleTitleSeparator = " (@"
+	profileHandleTitleSuffix    = ") / X"
+)
+
+func htmlFor(handle, displayName string) string {
 	// minimal HTML that satisfies our extractors
-	title := name
+	profileTitle := displayName
 	if handle != "" {
-		title = name + " (@" + handle + ") / X"
+		profileTitle = displayName + profileHandleTitleSeparator + handle + profileHandleTitleSuffix
 	}
-	return `<html><head><meta property="og:title" content="` + title + `"></head><body></body></html>`
+
+	var htmlBuilder strings.Builder
+	htmlBuilder.WriteString(htmlDocumentMetaPrefix)
+	htmlBuilder.WriteString(profileTitle)
+	htmlBuilder.WriteString(htmlDocumentHeadSuffix)
+	htmlBuilder.WriteString(htmlDocumentBodyOpenTag)
+	if handle != "" {
+		htmlBuilder.WriteString(htmlAnchorOpenPrefix)
+		htmlBuilder.WriteString(profileHandleURLPrefix)
+		htmlBuilder.WriteString(handle)
+		htmlBuilder.WriteString(htmlAnchorTextSeparator)
+		htmlBuilder.WriteString(profileHandleDisplayPrefix)
+		htmlBuilder.WriteString(handle)
+		htmlBuilder.WriteString(htmlAnchorCloseSuffix)
+	}
+	htmlBuilder.WriteString(htmlDocumentBodyCloseTag)
+
+	return htmlBuilder.String()
 }
 
 func TestResolveSuccess_FirstEndpoint(t *testing.T) {


### PR DESCRIPTION
## Summary
- ensure the html test fixture emits a canonical https://x.com/<handle> profile link when a handle is provided
- preserve the display name in the og:title tag so extractors continue to succeed

## Testing
- go test ./internal/xresolver


------
https://chatgpt.com/codex/tasks/task_e_68d1d8a29a0c83279e74456cca59e83e