### PR TITLE
Ensure Chrome renderer preserves default allocator flags

### DIFF
--- a/internal/xresolver/service.go
+++ b/internal/xresolver/service.go
@@ -91,7 +91,7 @@ func (r *ChromeRenderer) Render(ctx context.Context, userAgent, url string, vtBu
 		vtBudgetMS = defaultVirtualTimeBudgetMilliseconds
 	}
 
-	allocatorOptions := []chromedp.ExecAllocatorOption{
+	allocatorOptions := append(chromedp.DefaultExecAllocatorOptions[:], []chromedp.ExecAllocatorOption{
 		chromedp.Flag(chromeHeadlessFlagKey, true),
 		chromedp.Flag(chromeDisableGPUFlagKey, true),
 		chromedp.Flag(chromeUseGLFlagKey, chromeUseGLSwiftShaderValue),
@@ -103,7 +103,7 @@ func (r *ChromeRenderer) Render(ctx context.Context, userAgent, url string, vtBu
 		chromedp.Flag(chromeSilentFlagKey, true),
 		chromedp.Flag(chromeDisableLoggingFlagKey, true),
 		chromedp.Flag(chromeVirtualTimeBudgetFlagKey, strconv.Itoa(vtBudgetMS)),
-	}
+	}...)
 	if chromePath != "" {
 		allocatorOptions = append(allocatorOptions, chromedp.ExecPath(chromePath))
 	}


### PR DESCRIPTION
## Summary
- append the custom Chrome ExecAllocator flags after chromedp's defaults so required remote-debugging options are kept
- retain the existing headless, GPU, virtual time, and optional executable overrides after the defaults

## Testing
- go test ./internal/xresolver
- go run ./cmd/cresolve --chrome=/nonexistent 12345

------
https://chatgpt.com/codex/tasks/task_e_68d1e57557dc8327850cbe031fef1e91