### PR TITLE
Update chromedp headless options

### DIFF
--- a/internal/xresolver/service.go
+++ b/internal/xresolver/service.go
@@ -18,7 +18,9 @@ const (
 	defaultVirtualTimeBudgetMilliseconds = 15000
 
 	chromeHeadlessFlagKey              = "headless"
+	chromeHeadlessModeNewValue         = "new"
 	chromeDisableGPUFlagKey            = "disable-gpu"
+	chromeDisableGPUStartupFlagKey     = "disable-gpu-startup"
 	chromeUseGLFlagKey                 = "use-gl"
 	chromeUseGLSwiftShaderValue        = "swiftshader"
 	chromeEnableUnsafeSwiftShaderFlag  = "enable-unsafe-swiftshader"
@@ -92,8 +94,9 @@ func (r *ChromeRenderer) Render(ctx context.Context, userAgent, url string, vtBu
 	}
 
 	allocatorOptions := append(chromedp.DefaultExecAllocatorOptions[:], []chromedp.ExecAllocatorOption{
-		chromedp.Flag(chromeHeadlessFlagKey, true),
+		chromedp.Flag(chromeHeadlessFlagKey, chromeHeadlessModeNewValue),
 		chromedp.Flag(chromeDisableGPUFlagKey, true),
+		chromedp.Flag(chromeDisableGPUStartupFlagKey, true),
 		chromedp.Flag(chromeUseGLFlagKey, chromeUseGLSwiftShaderValue),
 		chromedp.Flag(chromeEnableUnsafeSwiftShaderFlag, true),
 		chromedp.Flag(chromeHideScrollbarsFlagKey, true),


### PR DESCRIPTION
## Summary
- add dedicated constants for the "new" headless mode and disable-gpu-startup flag in the resolver service
- update the chromedp allocator options to emit --headless=new and restore --disable-gpu-startup while keeping default exec options first

## Testing
- go test ./...
- go run ./cmd/cresolve -attempt-timeout=2s 12345 (fails: exec: "google-chrome": executable file not found in $PATH)


------
https://chatgpt.com/codex/tasks/task_e_68d1e94acaf4832799a356700b98da34