### PR TITLE
Add xresolver integration test and Chrome path helper

### DIFF
--- a/internal/utils/chromepath/path.go
+++ b/internal/utils/chromepath/path.go
@@ -1,0 +1,114 @@
+// Package chromepath provides helpers for discovering Chrome binary locations.
+package chromepath
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+const (
+	// EnvironmentVariableName is the environment variable consulted when resolving a Chrome binary.
+	EnvironmentVariableName = "CHROME_BIN"
+
+	chromeBinaryEmptyPathErrorMessage = "chrome binary path is empty"
+
+	macOSChromeBundlePath = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+	windowsChromeExecutableName      = "chrome.exe"
+	windowsChromeProgramFilesPath    = `C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe`
+	windowsChromeProgramFilesX86Path = `C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe`
+
+	linuxChromeStableExecutableName    = "google-chrome-stable"
+	linuxChromeExecutableName          = "google-chrome"
+	linuxChromiumExecutableName        = "chromium"
+	linuxChromiumBrowserExecutableName = "chromium-browser"
+	linuxChromeGenericExecutableName   = "chrome"
+
+	linuxChromeStableExecutablePath    = "/usr/bin/google-chrome-stable"
+	linuxChromeExecutablePath          = "/usr/bin/google-chrome"
+	linuxChromiumExecutablePath        = "/usr/bin/chromium"
+	linuxChromiumBrowserExecutablePath = "/usr/bin/chromium-browser"
+	linuxChromiumSnapExecutablePath    = "/snap/bin/chromium"
+
+	linuxChromeFallbackExecutableName = "google-chrome"
+)
+
+var (
+	linuxExecutableLookupOrder = []string{
+		linuxChromeStableExecutableName,
+		linuxChromeExecutableName,
+		linuxChromiumExecutableName,
+		linuxChromiumBrowserExecutableName,
+		linuxChromeGenericExecutableName,
+	}
+
+	linuxAbsoluteLookupOrder = []string{
+		linuxChromeStableExecutablePath,
+		linuxChromeExecutablePath,
+		linuxChromiumExecutablePath,
+		linuxChromiumBrowserExecutablePath,
+		linuxChromiumSnapExecutablePath,
+	}
+)
+
+// Discover returns the most appropriate Chrome binary path for the current platform.
+// The CHROME_BIN environment variable takes precedence, followed by platform-specific defaults.
+func Discover() string {
+	if environmentOverride := strings.TrimSpace(os.Getenv(EnvironmentVariableName)); environmentOverride != "" {
+		return environmentOverride
+	}
+	return DefaultPath()
+}
+
+// DefaultPath returns a best-effort Chrome binary path without consulting the environment.
+func DefaultPath() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return macOSChromeBundlePath
+	case "windows":
+		if resolvedPath, lookErr := exec.LookPath(windowsChromeExecutableName); lookErr == nil {
+			return resolvedPath
+		}
+		windowsCandidates := []string{windowsChromeProgramFilesPath, windowsChromeProgramFilesX86Path}
+		for _, candidate := range windowsCandidates {
+			if _, statErr := os.Stat(candidate); statErr == nil {
+				return candidate
+			}
+		}
+		return windowsChromeExecutableName
+	default:
+		for _, executableName := range linuxExecutableLookupOrder {
+			if resolvedPath, lookErr := exec.LookPath(executableName); lookErr == nil {
+				return resolvedPath
+			}
+		}
+		for _, candidatePath := range linuxAbsoluteLookupOrder {
+			if _, statErr := os.Stat(candidatePath); statErr == nil {
+				return candidatePath
+			}
+		}
+		return linuxChromeFallbackExecutableName
+	}
+}
+
+// ResolveExecutablePath verifies and resolves the provided Chrome binary hint into an executable path.
+func ResolveExecutablePath(binaryHint string) (string, error) {
+	trimmedHint := strings.TrimSpace(binaryHint)
+	if trimmedHint == "" {
+		return "", errors.New(chromeBinaryEmptyPathErrorMessage)
+	}
+	if strings.ContainsRune(trimmedHint, os.PathSeparator) {
+		if _, statErr := os.Stat(trimmedHint); statErr != nil {
+			return "", statErr
+		}
+		return trimmedHint, nil
+	}
+	resolvedPath, lookErr := exec.LookPath(trimmedHint)
+	if lookErr != nil {
+		return "", lookErr
+	}
+	return resolvedPath, nil
+}

--- a/tests/xresolver_integration_test.go
+++ b/tests/xresolver_integration_test.go
@@ -1,0 +1,118 @@
+package tests
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/f-sync/fsync/internal/utils/chromepath"
+	"github.com/f-sync/fsync/internal/xresolver"
+)
+
+const (
+	xresolverIntegrationFlagName                 = "xresolver_integration"
+	xresolverIntegrationFlagDescription          = "enable live xresolver integration test with Chrome handle resolution"
+	xresolverIntegrationFlagDisabledMessage      = "xresolver integration test skipped because the flag is disabled"
+	xresolverIntegrationChromeUnavailableMessage = "xresolver integration test skipped because no Chrome binary is available"
+
+	xresolverIntegrationScenarioResolveElon = "resolve elon musk via chrome renderer"
+
+	xresolverIntegrationAccountIDElon        = "44196397"
+	xresolverIntegrationExpectedHandleElon   = "elonmusk"
+	xresolverIntegrationExpectedDisplayElon  = "Elon Musk"
+	xresolverIntegrationExpectedProfileCount = 1
+
+	xresolverIntegrationUnexpectedProfileCountFormat = "expected %d profile results, got %d"
+	xresolverIntegrationUnexpectedResolveErrorFormat = "unexpected resolve error for account %s: %s"
+	xresolverIntegrationUnexpectedHandleFormat       = "expected handle %q for account %s, got %q"
+	xresolverIntegrationUnexpectedDisplayNameFormat  = "expected display name %q for account %s, got %q"
+	xresolverIntegrationEmptySourceURLFormat         = "expected non-empty source URL for account %s"
+	xresolverIntegrationFallbackErrorFormat          = "fallback chrome discovery failed (fallback error: %v, initial error: %v)"
+	xresolverIntegrationUnexpectedAccountIDFormat    = "expected account id %s, got %s"
+)
+
+const xresolverIntegrationContextTimeout = 2 * time.Minute
+
+var xresolverIntegrationRunFlag = flag.Bool(xresolverIntegrationFlagName, false, xresolverIntegrationFlagDescription)
+
+type xresolverIntegrationScenario struct {
+	scenarioName        string
+	accountID           string
+	expectedHandle      string
+	expectedDisplayName string
+}
+
+func TestXResolverChromeIntegration(t *testing.T) {
+	if !*xresolverIntegrationRunFlag {
+		t.Skip(xresolverIntegrationFlagDisabledMessage)
+	}
+
+	chromeBinaryPath, chromeErr := resolveChromeBinaryPathForXResolverIntegration()
+	if chromeErr != nil {
+		t.Skipf(integrationSkipMessageFormat, xresolverIntegrationChromeUnavailableMessage, chromeErr)
+	}
+
+	integrationService := xresolver.NewService(xresolver.Config{ChromePath: chromeBinaryPath}, xresolver.NewChromeRenderer())
+
+	scenarios := []xresolverIntegrationScenario{
+		{
+			scenarioName:        xresolverIntegrationScenarioResolveElon,
+			accountID:           xresolverIntegrationAccountIDElon,
+			expectedHandle:      xresolverIntegrationExpectedHandleElon,
+			expectedDisplayName: xresolverIntegrationExpectedDisplayElon,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		scenario := scenario
+		t.Run(scenario.scenarioName, func(t *testing.T) {
+			testContext, cancelTestContext := context.WithTimeout(context.Background(), xresolverIntegrationContextTimeout)
+			defer cancelTestContext()
+
+			request := xresolver.Request{IDs: []string{scenario.accountID}}
+			profiles := integrationService.ResolveBatch(testContext, request)
+			if len(profiles) != xresolverIntegrationExpectedProfileCount {
+				t.Fatalf(xresolverIntegrationUnexpectedProfileCountFormat, xresolverIntegrationExpectedProfileCount, len(profiles))
+			}
+
+			resolvedProfile := profiles[0]
+			if resolvedProfile.ID != scenario.accountID {
+				t.Fatalf(xresolverIntegrationUnexpectedAccountIDFormat, scenario.accountID, resolvedProfile.ID)
+			}
+			if resolvedProfile.Err != "" {
+				t.Fatalf(xresolverIntegrationUnexpectedResolveErrorFormat, scenario.accountID, resolvedProfile.Err)
+			}
+			if resolvedProfile.Handle != scenario.expectedHandle {
+				t.Fatalf(xresolverIntegrationUnexpectedHandleFormat, scenario.expectedHandle, scenario.accountID, resolvedProfile.Handle)
+			}
+			if resolvedProfile.DisplayName != scenario.expectedDisplayName {
+				t.Fatalf(xresolverIntegrationUnexpectedDisplayNameFormat, scenario.expectedDisplayName, scenario.accountID, resolvedProfile.DisplayName)
+			}
+			if strings.TrimSpace(resolvedProfile.FromURL) == "" {
+				t.Fatalf(xresolverIntegrationEmptySourceURLFormat, scenario.accountID)
+			}
+		})
+	}
+}
+
+func resolveChromeBinaryPathForXResolverIntegration() (string, error) {
+	discoveredPath := chromepath.Discover()
+	resolvedPath, resolveErr := chromepath.ResolveExecutablePath(discoveredPath)
+	if resolveErr == nil {
+		return resolvedPath, nil
+	}
+
+	defaultPath := chromepath.DefaultPath()
+	if strings.TrimSpace(defaultPath) == strings.TrimSpace(discoveredPath) {
+		return "", resolveErr
+	}
+
+	fallbackPath, fallbackErr := chromepath.ResolveExecutablePath(defaultPath)
+	if fallbackErr != nil {
+		return "", fmt.Errorf(xresolverIntegrationFallbackErrorFormat, fallbackErr, resolveErr)
+	}
+	return fallbackPath, nil
+}


### PR DESCRIPTION
## Summary
- add an internal chromepath utility to locate and validate Chrome binaries across platforms
- switch the cresolve CLI to reuse the shared Chrome discovery helper
- introduce a flagged xresolver integration test that exercises the real Chrome renderer against a known account

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1ea8593848327b70ed856d1c80942