### PR TITLE
Allow chromedp remote origins

### DIFF
--- a/internal/xresolver/service.go
+++ b/internal/xresolver/service.go
@@ -24,6 +24,8 @@ const (
 	chromeUseGLFlagKey                 = "use-gl"
 	chromeUseGLSwiftShaderValue        = "swiftshader"
 	chromeEnableUnsafeSwiftShaderFlag  = "enable-unsafe-swiftshader"
+	chromeRemoteAllowOriginsFlagKey    = "remote-allow-origins"
+	chromeRemoteAllowOriginsValue      = "*"
 	chromeHideScrollbarsFlagKey        = "hide-scrollbars"
 	chromeNoFirstRunFlagKey            = "no-first-run"
 	chromeNoDefaultBrowserCheckFlagKey = "no-default-browser-check"
@@ -109,6 +111,7 @@ func (renderer *ChromeRenderer) Render(ctx context.Context, userAgent, url strin
 		chromedp.Flag(chromeDisableGPUStartupFlagKey, true),
 		chromedp.Flag(chromeUseGLFlagKey, chromeUseGLSwiftShaderValue),
 		chromedp.Flag(chromeEnableUnsafeSwiftShaderFlag, true),
+		chromedp.Flag(chromeRemoteAllowOriginsFlagKey, chromeRemoteAllowOriginsValue),
 		chromedp.Flag(chromeHideScrollbarsFlagKey, true),
 		chromedp.Flag(chromeNoFirstRunFlagKey, true),
 		chromedp.Flag(chromeNoDefaultBrowserCheckFlagKey, true),


### PR DESCRIPTION
## Summary
- add constants for Chrome's remote-allow-origins flag
- include the remote allow origins flag when launching chromedp so DevTools can connect

## Testing
- go test ./...
- go test ./tests -run TestXResolverChromeIntegration -xresolver_integration


------
https://chatgpt.com/codex/tasks/task_e_68d2f1fa35a083278d595b03825823c0