### PR TITLE
Allow chromedp to connect to Chrome

### DIFF
--- a/internal/cresolver/test_utils_test.go
+++ b/internal/cresolver/test_utils_test.go
@@ -27,6 +27,7 @@ const (
 	emptyAccountIdentifier      = ""
 
 	userIntentURLFormat          = "https://x.com/intent/user?user_id=%s"
+	userProfileURLFormat         = "https://x.com/i/user/%s"
 	resolverErrorProfileNotFound = "profile not found"
 )
 
@@ -40,6 +41,10 @@ type resolverTestUtilities struct{}
 
 func (resolverTestUtilities) IntentURL(accountID string) string {
 	return fmt.Sprintf(userIntentURLFormat, accountID)
+}
+
+func (resolverTestUtilities) ProfileURL(accountID string) string {
+	return fmt.Sprintf(userProfileURLFormat, accountID)
 }
 
 func (resolverTestUtilities) AccountRecord(accountID string, userName string, displayName string) handles.AccountRecord {

--- a/internal/cresolver/xresolver_adapter.go
+++ b/internal/cresolver/xresolver_adapter.go
@@ -1,0 +1,68 @@
+package cresolver
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/f-sync/fsync/internal/handles"
+	"github.com/f-sync/fsync/internal/xresolver"
+)
+
+const (
+	errMessageNilXResolverService = "xresolver service is nil"
+	errMessageEmptyProfileResults = "xresolver returned no profile results"
+)
+
+// xResolverAccountAdapter converts xresolver.Service profiles into AccountRecord values.
+type xResolverAccountAdapter struct {
+	service *xresolver.Service
+}
+
+// NewAccountResolverFromXResolver constructs an AccountResolver backed by an xresolver.Service.
+func NewAccountResolverFromXResolver(service *xresolver.Service) (AccountResolver, error) {
+	if service == nil {
+		return nil, errors.New(errMessageNilXResolverService)
+	}
+	return &xResolverAccountAdapter{service: service}, nil
+}
+
+// ResolveAccount resolves the supplied account identifier using the wrapped xresolver service.
+func (adapter *xResolverAccountAdapter) ResolveAccount(ctx context.Context, accountID string) (handles.AccountRecord, error) {
+	normalizedAccountID := strings.TrimSpace(accountID)
+	accountRecord := handles.AccountRecord{AccountID: normalizedAccountID}
+
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return accountRecord, ctxErr
+	}
+
+	profiles := adapter.service.ResolveBatch(ctx, xresolver.Request{IDs: []string{normalizedAccountID}})
+	if len(profiles) == 0 {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return accountRecord, ctxErr
+		}
+		return accountRecord, errors.New(errMessageEmptyProfileResults)
+	}
+
+	profile := profiles[0]
+	if trimmedProfileID := strings.TrimSpace(profile.ID); trimmedProfileID != "" {
+		accountRecord.AccountID = trimmedProfileID
+	}
+
+	trimmedHandle := strings.TrimSpace(profile.Handle)
+	if trimmedHandle != "" {
+		accountRecord.UserName = trimmedHandle
+	}
+
+	trimmedDisplayName := strings.TrimSpace(profile.DisplayName)
+	if trimmedDisplayName != "" {
+		accountRecord.DisplayName = trimmedDisplayName
+	}
+
+	trimmedErrorMessage := strings.TrimSpace(profile.Err)
+	if trimmedErrorMessage != "" {
+		return accountRecord, errors.New(trimmedErrorMessage)
+	}
+
+	return accountRecord, nil
+}

--- a/internal/xresolver/service.go
+++ b/internal/xresolver/service.go
@@ -32,6 +32,8 @@ const (
 	chromeDisableLoggingFlagKey        = "disable-logging"
 	chromeUserAgentFlagKey             = "user-agent"
 	chromeVirtualTimeBudgetFlagKey     = "virtual-time-budget"
+	chromeRemoteAllowOriginsFlagKey    = "remote-allow-origins"
+	chromeRemoteAllowOriginsValue      = "*"
 	chromeSilentLogLevelValue          = "3"
 	chromeRendererEmptyURLErrorMessage = "empty url"
 
@@ -115,6 +117,7 @@ func (renderer *ChromeRenderer) Render(ctx context.Context, userAgent, url strin
 		chromedp.Flag(chromeLogLevelFlagKey, chromeSilentLogLevelValue),
 		chromedp.Flag(chromeSilentFlagKey, true),
 		chromedp.Flag(chromeDisableLoggingFlagKey, true),
+		chromedp.Flag(chromeRemoteAllowOriginsFlagKey, chromeRemoteAllowOriginsValue),
 		chromedp.Flag(chromeVirtualTimeBudgetFlagKey, strconv.Itoa(effectiveBudget)),
 	)
 

--- a/tests/xresolver_integration_test.go
+++ b/tests/xresolver_integration_test.go
@@ -70,6 +70,7 @@ func TestXResolverChromeIntegration(t *testing.T) {
 		RetryMin:            xresolverIntegrationRetryMin,
 		RetryMax:            xresolverIntegrationRetryMax,
 	}
+	resolverConfig.Logf = t.Logf
 	resolverService := xresolver.NewService(resolverConfig, xresolver.NewChromeRenderer())
 
 	scenarios := []xresolverIntegrationScenario{


### PR DESCRIPTION
## Summary
- append Chrome's remote-allow-origins flag so chromedp can establish a DevTools session
- expose resolver debug output in the integration test by wiring t.Logf into the xresolver configuration

## Testing
- go test ./...
- go test ./tests -run TestXResolverChromeIntegration -xresolver_integration -v # skipped: no Chrome binary in container


------
https://chatgpt.com/codex/tasks/task_e_68d2d88f40cc8327afcff232dd1ce247