### PR TITLE
Remove duplicate Chrome remote origin flag configuration

### DIFF
--- a/internal/xresolver/service.go
+++ b/internal/xresolver/service.go
@@ -40,8 +40,6 @@ const (
 	chromeIgnoreCertificateErrorsFlag  = "ignore-certificate-errors"
 	chromeUserAgentFlagKey             = "user-agent"
 	chromeVirtualTimeBudgetFlagKey     = "virtual-time-budget"
-	chromeRemoteAllowOriginsFlagKey    = "remote-allow-origins"
-	chromeRemoteAllowOriginsValue      = "*"
 	chromeProxyServerFlagKey           = "proxy-server"
 	httpsProxyEnvironmentUpper         = "HTTPS_PROXY"
 	httpsProxyEnvironmentLower         = "https_proxy"
@@ -143,7 +141,6 @@ func (renderer *ChromeRenderer) Render(ctx context.Context, userAgent, url strin
 		chromedp.Flag(chromeSilentFlagKey, true),
 		chromedp.Flag(chromeDisableLoggingFlagKey, true),
 		chromedp.Flag(chromeIgnoreCertificateErrorsFlag, true),
-		chromedp.Flag(chromeRemoteAllowOriginsFlagKey, chromeRemoteAllowOriginsValue),
 		chromedp.Flag(chromeVirtualTimeBudgetFlagKey, strconv.Itoa(effectiveBudget)),
 	)
 


### PR DESCRIPTION
## Summary
- remove the duplicate `remote-allow-origins` constants from the resolver service
- ensure the chromedp allocator only sets the remote origin flag once to avoid redeclaration errors

## Testing
- go fmt ./...
- go vet ./...
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d37c2bb4fc83278952605292768114